### PR TITLE
Add stdio MCP server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Configure reasoning effort levels to control how much the LLM "thinks" before re
 
 ### MCP Integration
 
-IDAssist can connect to external MCP servers for tool-augmented LLM interactions where the model can programmatically inspect functions, read disassembly, query cross-references, and modify the IDB during reasoning. IDAssist also provides built-in internal tools for function calling without requiring an external MCP server.
+IDAssist can connect to external MCP servers for tool-augmented LLM interactions where the model can programmatically inspect functions, read disassembly, query cross-references, and modify the IDB during reasoning. Both URL-based MCP servers (`SSE` or `Streamable HTTP`) and stdio-based MCP servers started from a local CLI command are supported. IDAssist also provides built-in internal tools for function calling without requiring an external MCP server.
 
 ### Function Calling
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ IDAssist organizes its functionality into seven tabs:
 
 ### MCP Tool Integration
 
-IDAssist provides built-in internal tools — function lookup, disassembly, pseudocode, cross-references, renaming, and graph queries — that LLMs can invoke during reasoning via function calling. You can also connect to external MCP servers for additional tool capabilities.
+IDAssist provides built-in internal tools — function lookup, disassembly, pseudocode, cross-references, renaming, and graph queries — that LLMs can invoke during reasoning via function calling. You can also connect to external MCP servers for additional tool capabilities, including URL-based and stdio-launched MCP servers.
 
 ### ReAct Agent
 

--- a/docs/tabs/settings-tab.md
+++ b/docs/tabs/settings-tab.md
@@ -81,9 +81,9 @@ When adding or editing a provider:
 | Column | Description |
 |--------|-------------|
 | **Name** | Unique name for the MCP server. |
-| **URL** | Server endpoint (e.g., `http://localhost:3000`). |
+| **Target** | HTTP endpoint for network transports, or the CLI command for stdio transports. |
 | **Enabled** | Whether this MCP server is active. |
-| **Transport** | Connection type (HTTP/SSE). |
+| **Transport** | Connection type (`SSE`, `Streamable HTTP`, or `Stdio`). |
 
 ### MCP Management Buttons
 
@@ -93,6 +93,23 @@ When adding or editing a provider:
 | **Edit** | Modify the selected MCP server's settings. |
 | **Delete** | Remove the selected MCP server. |
 | **Test** | Verify connectivity to the MCP server. |
+
+### MCP Transport Modes
+
+Use one of these transport styles when adding an MCP provider:
+
+| Transport | Required Fields | Notes |
+|----------|-----------------|-------|
+| `sse` | `URL` | For MCP servers exposed over SSE, such as `http://localhost:8000/sse`. |
+| `streamablehttp` | `URL` | For MCP servers exposed over streamable HTTP, such as `http://localhost:8000/mcp`. |
+| `stdio` | `Command` | Starts a local MCP server process and talks to it over stdin/stdout. |
+
+For `stdio` providers, the dialog also supports:
+- **Arguments**: Command-line arguments. Enter either shell-style arguments or a JSON string array.
+- **Working Directory**: Optional process working directory.
+- **Environment JSON**: Optional JSON object of environment variables, for example `{"API_KEY":"value"}`.
+
+On Windows, stdio MCP providers also require `pywin32` in the same Python environment as IDA because the MCP SDK uses Windows Job Objects for child-process management.
 
 ## System Prompt
 

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -28,7 +28,8 @@
       "anyio>=4.6",
       "mcp==1.23.3",
       "whoosh",
-      "aiohttp"
+      "aiohttp",
+      "pywin32; platform_system == \"Windows\""
     ]
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ anyio>=4.6
 mcp==1.23.3
 whoosh
 aiohttp
+pywin32; platform_system == "Windows"

--- a/src/controllers/settings_controller.py
+++ b/src/controllers/settings_controller.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
 import asyncio
+import json
+import os
+import shlex
 from ..qt_compat import (QMessageBox, QInputDialog, QDialog, QVBoxLayout, QHBoxLayout,
                          QLabel, QLineEdit, QPushButton, QCheckBox, QSpinBox, QComboBox,
                          QObject, QThread, Signal, exec_dialog)
@@ -21,6 +24,33 @@ from ..services.symgraph_service import symgraph_service, SymGraphAuthError, Sym
 from ..views.settings_tab_view import SettingsTabView
 
 PROVIDER_WORKER_TIMEOUT_BUFFER_SECONDS = 5.0
+
+
+def parse_mcp_args(raw_args):
+    """Parse MCP stdio args from a UI string."""
+    value = (raw_args or "").strip()
+    if not value:
+        return []
+
+    if value.startswith("["):
+        parsed = json.loads(value)
+        if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+            raise ValueError("Args JSON must be an array of strings.")
+        return parsed
+
+    return shlex.split(value, posix=(os.name != "nt"))
+
+
+def parse_mcp_env(raw_env):
+    """Parse MCP stdio environment variables from a UI string."""
+    value = (raw_env or "").strip()
+    if not value:
+        return {}
+
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict) or not all(isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()):
+        raise ValueError("Environment JSON must be an object of string keys and string values.")
+    return parsed
 
 
 def validate_provider_test_config(provider_config):
@@ -311,12 +341,16 @@ class MCPTestWorker(QThread):
         try:
             log.log_info(f"Testing MCP server '{server_name}'...")
 
-            transport_type = self.server_config.get('transport', 'sse')
+            transport_type = self.server_config.get('transport', 'streamablehttp')
 
             config = MCPServerConfig(
                 name=self.server_config['name'],
                 transport_type=transport_type,
-                url=self.server_config['url'],
+                url=self.server_config.get('url'),
+                command=self.server_config.get('command'),
+                args=self.server_config.get('args'),
+                env=self.server_config.get('env'),
+                cwd=self.server_config.get('cwd'),
                 enabled=self.server_config.get('enabled', True),
                 timeout=30.0
             )
@@ -352,6 +386,8 @@ class MCPTestWorker(QThread):
                     error_message += "\n- Verify the server supports MCP over SSE"
                 elif "connection refused" in result.error.lower():
                     error_message += "\n\nSuggestion: Check if the server is running on the specified port"
+                elif transport_type == "stdio":
+                    error_message += "\n\nSuggestion: Verify the command, working directory, and PATH/environment values."
 
                 self.test_completed.emit(False, error_message, {})
 
@@ -1309,23 +1345,46 @@ class MCPProviderDialog(QDialog):
     def setup_ui(self):
         self.setWindowTitle("MCP Provider" if not self.provider_data else f"Edit {self.provider_data.get('name', 'Provider')}")
         self.setModal(True)
-        self.resize(400, 300)
+        self.resize(480, 360)
 
         layout = QVBoxLayout()
 
-        layout.addWidget(QLabel("Name:"))
+        self.name_label = QLabel("Name:")
+        layout.addWidget(self.name_label)
         self.name_edit = QLineEdit()
         layout.addWidget(self.name_edit)
-
-        layout.addWidget(QLabel("URL:"))
-        self.url_edit = QLineEdit()
-        layout.addWidget(self.url_edit)
 
         layout.addWidget(QLabel("Transport:"))
         self.transport_combo = QComboBox()
         self.transport_combo.addItem("SSE (HTTP)", "sse")
         self.transport_combo.addItem("Streamable HTTP", "streamablehttp")
+        self.transport_combo.addItem("Stdio (CLI Process)", "stdio")
         layout.addWidget(self.transport_combo)
+
+        self.url_label = QLabel("URL:")
+        layout.addWidget(self.url_label)
+        self.url_edit = QLineEdit()
+        layout.addWidget(self.url_edit)
+
+        self.command_label = QLabel("Command:")
+        layout.addWidget(self.command_label)
+        self.command_edit = QLineEdit()
+        layout.addWidget(self.command_edit)
+
+        self.args_label = QLabel("Arguments:")
+        layout.addWidget(self.args_label)
+        self.args_edit = QLineEdit()
+        layout.addWidget(self.args_edit)
+
+        self.cwd_label = QLabel("Working Directory:")
+        layout.addWidget(self.cwd_label)
+        self.cwd_edit = QLineEdit()
+        layout.addWidget(self.cwd_edit)
+
+        self.env_label = QLabel("Environment JSON:")
+        layout.addWidget(self.env_label)
+        self.env_edit = QLineEdit()
+        layout.addWidget(self.env_edit)
 
         self.transport_combo.currentTextChanged.connect(self.on_transport_changed)
         self.on_transport_changed()
@@ -1350,18 +1409,41 @@ class MCPProviderDialog(QDialog):
     def on_transport_changed(self):
         """Handle transport type change"""
         transport_data = self.transport_combo.currentData()
+        is_stdio = transport_data == "stdio"
+
+        self.url_label.setVisible(not is_stdio)
+        self.url_edit.setVisible(not is_stdio)
+        self.command_label.setVisible(is_stdio)
+        self.command_edit.setVisible(is_stdio)
+        self.args_label.setVisible(is_stdio)
+        self.args_edit.setVisible(is_stdio)
+        self.cwd_label.setVisible(is_stdio)
+        self.cwd_edit.setVisible(is_stdio)
+        self.env_label.setVisible(is_stdio)
+        self.env_edit.setVisible(is_stdio)
+
         if transport_data == "sse":
             self.url_edit.setPlaceholderText("e.g., http://localhost:8000/sse")
-        else:
+        elif transport_data == "streamablehttp":
             self.url_edit.setPlaceholderText("e.g., http://localhost:8000/mcp")
+        else:
+            self.command_edit.setPlaceholderText("e.g., npx")
+            self.args_edit.setPlaceholderText("e.g., -y @modelcontextprotocol/server-filesystem C:\\work")
+            self.cwd_edit.setPlaceholderText("Optional process working directory")
+            self.env_edit.setPlaceholderText('Optional JSON, e.g. {"API_KEY":"value"}')
 
     def populate_fields(self):
         """Populate fields with existing provider data"""
         if self.provider_data:
             self.name_edit.setText(self.provider_data.get('name', ''))
             self.url_edit.setText(self.provider_data.get('url', ''))
+            self.command_edit.setText(self.provider_data.get('command', ''))
+            self.args_edit.setText(' '.join(self.provider_data.get('args', [])))
+            env_data = self.provider_data.get('env', {})
+            self.env_edit.setText(json.dumps(env_data) if env_data else '')
+            self.cwd_edit.setText(self.provider_data.get('cwd', ''))
 
-            raw_transport = self.provider_data.get('transport', 'sse').lower().strip()
+            raw_transport = self.provider_data.get('transport', 'streamablehttp').lower().strip()
             # Normalize legacy transport values
             transport_map = {'http': 'streamablehttp', 'streamable_http': 'streamablehttp'}
             transport_value = transport_map.get(raw_transport, raw_transport)
@@ -1374,9 +1456,15 @@ class MCPProviderDialog(QDialog):
 
     def get_provider_data(self):
         """Get the provider data from the form"""
+        args = parse_mcp_args(self.args_edit.text())
+        env = parse_mcp_env(self.env_edit.text())
         return {
             'name': self.name_edit.text().strip(),
             'url': self.url_edit.text().strip(),
+            'command': self.command_edit.text().strip(),
+            'args': args,
+            'env': env,
+            'cwd': self.cwd_edit.text().strip(),
             'transport': self.transport_combo.currentData(),
             'enabled': self.enabled_check.isChecked()
         }
@@ -1453,8 +1541,9 @@ class SettingsController(QObject):
 
             mcp_providers = self.service.get_mcp_providers()
             for provider in mcp_providers:
+                target = provider['command'] if provider.get('transport') == 'stdio' else provider['url']
                 self.view.add_mcp_provider(
-                    provider['name'], provider['url'],
+                    provider['name'], target,
                     provider['enabled'], provider['transport']
                 )
 
@@ -1675,12 +1764,22 @@ class SettingsController(QObject):
         if exec_dialog(dialog) == QDialog.Accepted:
             try:
                 data = dialog.get_provider_data()
-                if not all([data['name'], data['url']]):
-                    self.show_error("Validation Error", "Name and URL are required fields.")
+                if not data['name']:
+                    self.show_error("Validation Error", "Name is required.")
+                    return
+                if data['transport'] == 'stdio' and not data['command']:
+                    self.show_error("Validation Error", "Command is required for stdio MCP providers.")
+                    return
+                if data['transport'] != 'stdio' and not data['url']:
+                    self.show_error("Validation Error", "URL is required for HTTP MCP providers.")
                     return
 
-                provider_id = self.service.add_mcp_provider(
-                    data['name'], data['url'], data['enabled'], data['transport']
+                self.service.add_mcp_provider(
+                    data['name'], data['url'], data['enabled'], data['transport'],
+                    command=data.get('command', ''),
+                    args=data.get('args', []),
+                    env=data.get('env', {}),
+                    cwd=data.get('cwd', '')
                 )
                 self.load_initial_data()
                 self.show_info("Success", f"Added MCP provider '{data['name']}'")
@@ -1702,8 +1801,14 @@ class SettingsController(QObject):
 
             if exec_dialog(dialog) == QDialog.Accepted:
                 data = dialog.get_provider_data()
-                if not all([data['name'], data['url']]):
-                    self.show_error("Validation Error", "Name and URL are required fields.")
+                if not data['name']:
+                    self.show_error("Validation Error", "Name is required.")
+                    return
+                if data['transport'] == 'stdio' and not data['command']:
+                    self.show_error("Validation Error", "Command is required for stdio MCP providers.")
+                    return
+                if data['transport'] != 'stdio' and not data['url']:
+                    self.show_error("Validation Error", "URL is required for HTTP MCP providers.")
                     return
                 self.service.update_mcp_provider(provider['id'], **data)
                 self.load_initial_data()
@@ -1723,7 +1828,11 @@ class SettingsController(QObject):
             new_name = provider['name'] + " - Copy"
             self.service.add_mcp_provider(
                 new_name, provider['url'],
-                provider.get('enabled', True), provider.get('transport', 'sse')
+                provider.get('enabled', True), provider.get('transport', 'sse'),
+                command=provider.get('command', ''),
+                args=provider.get('args', []),
+                env=provider.get('env', {}),
+                cwd=provider.get('cwd', '')
             )
             self.load_initial_data()
             self.show_info("Success", f"Duplicated MCP provider as '{new_name}'")
@@ -1760,7 +1869,12 @@ class SettingsController(QObject):
                 return
             provider = providers[row]
 
-            if not provider.get('url'):
+            if provider.get('transport') == 'stdio' and not provider.get('command'):
+                self.view.set_mcp_test_status('failure',
+                    f"Provider '{provider['name']}' has no command configured.")
+                return
+
+            if provider.get('transport') != 'stdio' and not provider.get('url'):
                 self.view.set_mcp_test_status('failure',
                     f"Provider '{provider['name']}' has no URL configured.")
                 return

--- a/src/services/mcp_client.py
+++ b/src/services/mcp_client.py
@@ -7,6 +7,8 @@ for connecting to and interacting with MCP servers using the official MCP Python
 """
 
 import asyncio
+import os
+import sys
 from typing import Dict, List, Optional, Any, Union
 from dataclasses import dataclass
 import json
@@ -16,34 +18,46 @@ from .mcp_exceptions import MCPError, MCPConnectionError, MCPTimeoutError, MCPTo
 
 from src.ida_compat import log
 
+MCP_SDK_IMPORT_ERROR = None
+STDIO_IMPORT_ERROR = None
+
 # Import MCP SDK
 try:
-    from mcp import ClientSession, types
-    # Check if SSE client is available
-    try:
-        from mcp.client.sse import sse_client
-        SSE_CLIENT_AVAILABLE = True
-    except ImportError as e:
-        log.log_warn(f"MCP SSE client not available: {e}")
-        sse_client = None
-        SSE_CLIENT_AVAILABLE = False
-    # Check if Streamable HTTP client is available
-    try:
-        from mcp.client.streamable_http import streamablehttp_client
-        STREAMABLEHTTP_CLIENT_AVAILABLE = True
-    except ImportError as e:
-        log.log_warn(f"MCP Streamable HTTP client not available: {e}")
-        streamablehttp_client = None
-        STREAMABLEHTTP_CLIENT_AVAILABLE = False
+    from mcp.client.session import ClientSession
+    import mcp.types as types
     MCP_SDK_AVAILABLE = True
-except ImportError:
-    log.log_warn("MCP SDK not available. Install with: pip install mcp")
+except Exception as e:
+    MCP_SDK_IMPORT_ERROR = e
+    log.log_warn(f"MCP SDK core imports unavailable: {e}")
     MCP_SDK_AVAILABLE = False
     ClientSession = None
+    types = None
+
+try:
+    from mcp.client.sse import sse_client
+    SSE_CLIENT_AVAILABLE = True
+except Exception as e:
+    log.log_warn(f"MCP SSE client not available: {e}")
     sse_client = None
     SSE_CLIENT_AVAILABLE = False
+
+try:
+    from mcp.client.streamable_http import streamablehttp_client
+    STREAMABLEHTTP_CLIENT_AVAILABLE = True
+except Exception as e:
+    log.log_warn(f"MCP Streamable HTTP client not available: {e}")
     streamablehttp_client = None
     STREAMABLEHTTP_CLIENT_AVAILABLE = False
+
+try:
+    from mcp.client.stdio import stdio_client, StdioServerParameters
+    STDIO_CLIENT_AVAILABLE = True
+except Exception as e:
+    STDIO_IMPORT_ERROR = e
+    log.log_warn(f"MCP stdio client not available: {e}")
+    stdio_client = None
+    StdioServerParameters = None
+    STDIO_CLIENT_AVAILABLE = False
 
 
 class MCPConnection:
@@ -59,17 +73,22 @@ class MCPConnection:
         self.resources: Dict[str, MCPResource] = {}
         self._sse_context = None
         self._streamablehttp_context = None
+        self._stdio_context = None
+        self._stdio_errlog = None
 
     async def connect(self) -> bool:
         """Connect to the MCP server."""
         if not MCP_SDK_AVAILABLE:
-            raise MCPError("MCP SDK not available. Please install with: pip install mcp")
+            detail = f" ({MCP_SDK_IMPORT_ERROR})" if MCP_SDK_IMPORT_ERROR else ""
+            raise MCPError(f"MCP SDK core imports unavailable{detail}. Ensure 'mcp' is installed in IDA's Python environment.")
 
         try:
             if self.config.transport_type == "sse":
                 await self._connect_sse()
             elif self.config.transport_type == "streamablehttp":
                 await self._connect_streamablehttp()
+            elif self.config.transport_type == "stdio":
+                await self._connect_stdio()
             else:
                 raise MCPError(f"Unsupported transport type: {self.config.transport_type}")
 
@@ -108,8 +127,36 @@ class MCPConnection:
                 pass
             self._streamablehttp_context = None
 
+        if self._stdio_context:
+            try:
+                await self._stdio_context.__aexit__(None, None, None)
+            except Exception:
+                pass
+            self._stdio_context = None
+
+        if self._stdio_errlog:
+            try:
+                self._stdio_errlog.close()
+            except Exception:
+                pass
+            self._stdio_errlog = None
+
         self.read = None
         self.write = None
+
+    def _get_stdio_errlog(self):
+        """Get a real file handle for stdio server stderr under IDA/Windows."""
+        candidates = [getattr(sys, "__stderr__", None), getattr(sys, "stderr", None)]
+        for candidate in candidates:
+            if candidate and hasattr(candidate, "fileno"):
+                try:
+                    candidate.fileno()
+                    return candidate
+                except Exception:
+                    pass
+
+        self._stdio_errlog = open(os.devnull, "w", encoding="utf-8")
+        return self._stdio_errlog
 
     async def _connect_sse(self):
         """Connect using SSE transport."""
@@ -151,6 +198,35 @@ class MCPConnection:
         await self.session.__aenter__()
 
         # Initialize with timeout
+        try:
+            await asyncio.wait_for(self.session.initialize(), timeout=self.config.timeout)
+        except asyncio.TimeoutError:
+            raise MCPError(f"Session initialization timed out after {self.config.timeout} seconds")
+
+    async def _connect_stdio(self):
+        """Connect using stdio transport."""
+        if not self.config.command:
+            raise MCPError("Command not specified for stdio transport")
+
+        if not STDIO_CLIENT_AVAILABLE:
+            detail = f": {STDIO_IMPORT_ERROR}" if STDIO_IMPORT_ERROR else ""
+            raise MCPError(
+                "Stdio client not available in MCP SDK"
+                f"{detail}. On Windows, install 'pywin32' in the same Python environment as IDA."
+            )
+
+        server_params = StdioServerParameters(
+            command=self.config.command,
+            args=self.config.args or [],
+            env=self.config.env,
+            cwd=self.config.cwd or None,
+        )
+        self._stdio_context = stdio_client(server_params, errlog=self._get_stdio_errlog())
+        self.read, self.write = await self._stdio_context.__aenter__()
+
+        self.session = ClientSession(self.read, self.write)
+        await self.session.__aenter__()
+
         try:
             await asyncio.wait_for(self.session.initialize(), timeout=self.config.timeout)
         except asyncio.TimeoutError:

--- a/src/services/mcp_client_service.py
+++ b/src/services/mcp_client_service.py
@@ -98,12 +98,13 @@ class MCPClientService:
             for server_data in servers_data:
                 try:
                     # Normalize transport value from settings DB
-                    raw_transport = server_data.get('transport', 'sse').lower().strip()
+                    raw_transport = server_data.get('transport', 'streamablehttp').lower().strip()
                     transport_map = {
                         'http': 'streamablehttp',
                         'streamablehttp': 'streamablehttp',
                         'streamable_http': 'streamablehttp',
                         'sse': 'sse',
+                        'stdio': 'stdio',
                     }
                     transport_type = transport_map.get(raw_transport, 'streamablehttp')
 
@@ -113,7 +114,11 @@ class MCPClientService:
                         'transport_type': transport_type,
                         'enabled': server_data.get('enabled', True),
                         'url': server_data.get('url'),
-                        'timeout': server_data.get('timeout', 30.0)
+                        'timeout': server_data.get('timeout', 30.0),
+                        'command': server_data.get('command'),
+                        'args': server_data.get('args'),
+                        'env': server_data.get('env'),
+                        'cwd': server_data.get('cwd')
                     }
 
                     config = MCPServerConfig.from_dict(config_dict)

--- a/src/services/migrations/__init__.py
+++ b/src/services/migrations/__init__.py
@@ -4,6 +4,7 @@ from .add_provider_type import migrate_add_provider_type
 from .add_reasoning_effort import migrate_add_reasoning_effort
 from .add_litellm_configs import migrate_add_litellm_configs
 from .add_provider_timeout import migrate_add_provider_timeout
+from .add_mcp_stdio_fields import migrate_add_mcp_stdio_fields
 from .migrate_provider_type_names import migrate_provider_type_names
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     'migrate_add_reasoning_effort',
     'migrate_add_litellm_configs',
     'migrate_add_provider_timeout',
+    'migrate_add_mcp_stdio_fields',
     'migrate_provider_type_names'
 ]

--- a/src/services/migrations/add_mcp_stdio_fields.py
+++ b/src/services/migrations/add_mcp_stdio_fields.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+"""
+Migration: Add stdio transport fields to mcp_providers table.
+"""
+
+import sqlite3
+
+from src.ida_compat import log
+
+
+def migrate_add_mcp_stdio_fields(db_path: str):
+    """Add stdio-related columns to mcp_providers if they do not exist."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+
+        cursor.execute("PRAGMA table_info(mcp_providers)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        field_definitions = {
+            'command': "ALTER TABLE mcp_providers ADD COLUMN command TEXT DEFAULT ''",
+            'args': "ALTER TABLE mcp_providers ADD COLUMN args TEXT DEFAULT '[]'",
+            'env': "ALTER TABLE mcp_providers ADD COLUMN env TEXT DEFAULT '{}'",
+            'cwd': "ALTER TABLE mcp_providers ADD COLUMN cwd TEXT DEFAULT ''",
+        }
+
+        for column_name, statement in field_definitions.items():
+            if column_name not in columns:
+                cursor.execute(statement)
+                conn.commit()
+                log.log_info(f"Added {column_name} column to mcp_providers")
+            else:
+                log.log_debug(f"{column_name} column already exists on mcp_providers")
+
+    except Exception as e:
+        conn.rollback()
+        log.log_error(f"mcp stdio fields migration failed: {e}")
+        raise
+    finally:
+        conn.close()

--- a/src/services/models/mcp_models.py
+++ b/src/services/models/mcp_models.py
@@ -22,6 +22,7 @@ class MCPTransportType(Enum):
     """MCP transport protocol types."""
     SSE = "sse"
     STREAMABLEHTTP = "streamablehttp"
+    STDIO = "stdio"
 
 
 @dataclass
@@ -36,10 +37,20 @@ class MCPServerConfig:
     url: Optional[str] = None
     headers: Optional[Dict[str, str]] = None
 
+    # Stdio transport fields
+    command: Optional[str] = None
+    args: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None
+    cwd: Optional[str] = None
+
     def __post_init__(self):
         """Validate configuration after initialization."""
         if self.transport_type in ("sse", "streamablehttp") and not self.url:
             raise ValueError(f"{self.transport_type} transport requires url")
+        if self.transport_type == "stdio" and not self.command:
+            raise ValueError("stdio transport requires command")
+        if self.args is None:
+            self.args = []
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'MCPServerConfig':
@@ -50,7 +61,11 @@ class MCPServerConfig:
             enabled=data.get('enabled', True),
             timeout=data.get('timeout', 30.0),
             url=data.get('url'),
-            headers=data.get('headers')
+            headers=data.get('headers'),
+            command=data.get('command'),
+            args=data.get('args'),
+            env=data.get('env'),
+            cwd=data.get('cwd')
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -61,7 +76,11 @@ class MCPServerConfig:
             'enabled': self.enabled,
             'timeout': self.timeout,
             'url': self.url,
-            'headers': self.headers
+            'headers': self.headers,
+            'command': self.command,
+            'args': self.args,
+            'env': self.env,
+            'cwd': self.cwd
         }
 
 

--- a/src/services/settings_service.py
+++ b/src/services/settings_service.py
@@ -114,6 +114,10 @@ class SettingsService:
                         url TEXT NOT NULL,
                         enabled BOOLEAN DEFAULT 1,
                         transport TEXT DEFAULT 'streamablehttp',
+                        command TEXT DEFAULT '',
+                        args TEXT DEFAULT '[]',
+                        env TEXT DEFAULT '{}',
+                        cwd TEXT DEFAULT '',
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                     )
@@ -140,6 +144,7 @@ class SettingsService:
                 migrate_add_reasoning_effort,
                 migrate_add_litellm_configs,
                 migrate_add_provider_timeout,
+                migrate_add_mcp_stdio_fields,
                 migrate_provider_type_names
             )
             from .migrations.add_oauth_credentials import migrate_add_oauth_credentials
@@ -148,6 +153,7 @@ class SettingsService:
             migrate_add_reasoning_effort(self._db_path)
             migrate_add_litellm_configs(self._db_path)
             migrate_add_provider_timeout(self._db_path)
+            migrate_add_mcp_stdio_fields(self._db_path)
             migrate_add_oauth_credentials(self._db_path)
             migrate_provider_type_names(self._db_path)
             migrate_add_bypass_proxy(self._db_path)
@@ -616,16 +622,35 @@ class SettingsService:
 
     # MCP Provider Operations
 
-    def add_mcp_provider(self, name: str, url: str, enabled: bool = True, transport: str = 'streamablehttp') -> int:
+    def add_mcp_provider(
+        self,
+        name: str,
+        url: str,
+        enabled: bool = True,
+        transport: str = 'streamablehttp',
+        command: str = '',
+        args: Optional[List[str]] = None,
+        env: Optional[Dict[str, str]] = None,
+        cwd: str = ''
+    ) -> int:
         """Add a new MCP provider"""
         with self._db_lock:
             conn = self._get_connection()
             try:
                 cursor = conn.cursor()
                 cursor.execute('''
-                    INSERT INTO mcp_providers (name, url, enabled, transport)
-                    VALUES (?, ?, ?, ?)
-                ''', (name, url, enabled, transport))
+                    INSERT INTO mcp_providers (name, url, enabled, transport, command, args, env, cwd)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ''', (
+                    name,
+                    url,
+                    enabled,
+                    transport,
+                    command,
+                    json.dumps(args or []),
+                    json.dumps(env or {}),
+                    cwd
+                ))
 
                 provider_id = cursor.lastrowid
                 conn.commit()
@@ -646,7 +671,7 @@ class SettingsService:
             try:
                 cursor = conn.cursor()
                 cursor.execute('''
-                    SELECT id, name, url, enabled, transport
+                    SELECT id, name, url, enabled, transport, command, args, env, cwd
                     FROM mcp_providers ORDER BY name
                 ''')
 
@@ -657,7 +682,11 @@ class SettingsService:
                         'name': row[1],
                         'url': row[2],
                         'enabled': bool(row[3]),
-                        'transport': row[4]
+                        'transport': row[4],
+                        'command': row[5] or '',
+                        'args': self._deserialize_value(row[6] or '[]', 'json'),
+                        'env': self._deserialize_value(row[7] or '{}', 'json'),
+                        'cwd': row[8] or ''
                     })
 
                 return providers
@@ -669,11 +698,16 @@ class SettingsService:
 
     def update_mcp_provider(self, provider_id: int, **kwargs) -> bool:
         """Update an MCP provider"""
-        valid_fields = {'name', 'url', 'enabled', 'transport'}
+        valid_fields = {'name', 'url', 'enabled', 'transport', 'command', 'args', 'env', 'cwd'}
         update_fields = {k: v for k, v in kwargs.items() if k in valid_fields}
 
         if not update_fields:
             return False
+
+        if 'args' in update_fields:
+            update_fields['args'] = json.dumps(update_fields['args'] or [])
+        if 'env' in update_fields:
+            update_fields['env'] = json.dumps(update_fields['env'] or {})
 
         with self._db_lock:
             conn = self._get_connection()

--- a/src/views/settings_tab_view.py
+++ b/src/views/settings_tab_view.py
@@ -159,7 +159,7 @@ class SettingsTabView(QWidget):
         self.mcp_table = QTableWidget()
         self.mcp_table.setColumnCount(4)
         self.mcp_table.setHorizontalHeaderLabels([
-            "Name", "URL", "Enabled", "Transport"
+            "Name", "Target", "Enabled", "Transport"
         ])
 
         # Configure table
@@ -438,13 +438,13 @@ class SettingsTabView(QWidget):
         # Update active provider combo
         self.active_provider_combo.addItem(name)
 
-    def add_mcp_provider(self, name, url, enabled=True, transport="streamablehttp"):
+    def add_mcp_provider(self, name, target, enabled=True, transport="streamablehttp"):
         """Add an MCP provider to the table"""
         row_count = self.mcp_table.rowCount()
         self.mcp_table.insertRow(row_count)
 
         self.mcp_table.setItem(row_count, 0, QTableWidgetItem(name))
-        self.mcp_table.setItem(row_count, 1, QTableWidgetItem(url))
+        self.mcp_table.setItem(row_count, 1, QTableWidgetItem(target))
 
         enabled_checkbox = QCheckBox()
         enabled_checkbox.setChecked(enabled)


### PR DESCRIPTION
## Summary
- add stdio-based MCP server support alongside SSE and streamable HTTP
- extend MCP provider settings, persistence, and migration handling for command/args/env/cwd
- improve Windows stdio startup compatibility in IDA, including clearer MCP import errors and a real stderr handle for subprocess startup
