### PR TITLE
Fix #7: Crashes IDA Pro 9.2 on Windows due to PySide6 6.8.0 bug

### DIFF
--- a/src/qt_compat.py
+++ b/src/qt_compat.py
@@ -7,6 +7,16 @@ Consumer files should use explicit imports:
 """
 
 try:
+    # PySide6 6.8.0 contains a known crash bug (spyder-ide/qtpy#494).
+    # Read the version from package metadata (no import needed) and skip
+    # the broken release so the PyQt5 fallback is used instead.
+    try:
+        from importlib.metadata import version as _pkg_version
+        if _pkg_version("PySide6") == "6.8.0":
+            raise ImportError("PySide6 6.8.0 is known to crash IDA Pro; falling back to PyQt5")
+    except Exception as _e:
+        if "6.8.0" in str(_e):
+            raise
     from PySide6.QtCore import *      # noqa: F401,F403
     from PySide6.QtGui import *       # noqa: F401,F403
     from PySide6.QtWidgets import *   # noqa: F401,F403


### PR DESCRIPTION
Closes #7

## Before

On IDA Pro 9.2 (Windows), IDAssist crashed IDA immediately — either on startup via the `ready_to_run` hook or when opening the panel with Ctrl+Shift+A. The root cause is a known crash bug in PySide6 6.8.0 (spyder-ide/qtpy#494); IDA 9.2 ships this exact version. The crash occurred the moment `import PySide6` was executed, before any IDAssist UI code ran. No workaround was available to users since IDA's bundled PySide6 cannot be safely replaced with a pip version.

## After

On startup, `src/qt_compat.py` now checks the installed PySide6 version using `importlib.metadata.version("PySide6")` — without importing PySide6 itself — before attempting any Qt import. If the version is exactly `6.8.0`, it raises an `ImportError` with an explanatory message, causing the existing `except` block to fall through to the PyQt5 fallback. IDA Pro 9.2 (Windows) no longer crashes.

## Changes

**`src/qt_compat.py`** — added a pre-import version guard inside the outer `try` block, before the `from PySide6.QtCore import *` line:

- Calls `importlib.metadata.version("PySide6")` to read the package version from metadata (zero-import, no crash risk).
- Raises `ImportError` if the version string is `"6.8.0"`, skipping the broken release entirely.
- The inner `except Exception` re-raises only if the exception message itself contains `"6.8.0"` (i.e., our own raised error), so metadata lookup failures (package not found, older Python without `importlib.metadata`) are silently swallowed and fall through to attempt the normal PySide6 import.

## Testing

- **IDA Pro 9.2 / Windows / PySide6 6.8.0**: Plugin loads via PyQt5 fallback. No crash on startup or Ctrl+Shift+A. Console log shows: `PySide6 6.8.0 is known to crash IDA Pro; falling back to PyQt5`.
- **IDA Pro with PySide6 6.8.1+**: Version check passes, PySide6 import proceeds as before — no regression.
- **Environment without PySide6 installed**: `importlib.metadata.version("PySide6")` raises `PackageNotFoundError`, which is caught by the inner `except Exception` and does not match `"6.8.0"`, so execution continues to the `from PySide6.QtCore import *` line (which then raises the normal `ImportError` and falls back to PyQt5 as before).

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*