### PR TITLE
Fix semantic analysis context and OAuth response parsing

### DIFF
--- a/src/services/binary_context_service.py
+++ b/src/services/binary_context_service.py
@@ -69,15 +69,10 @@ class BinaryContextService:
         """Get the cached binary hash."""
         return self._cached_binary_hash
 
-    def get_current_context(self) -> Dict[str, Any]:
-        """Get complete context snapshot for current state"""
-        if not _IN_IDA:
-            return {"error": "Not running inside IDA Pro"}
-
-        # Update current offset from IDA cursor
-        self._current_offset = ida_kernwin.get_screen_ea()
-
-        context = {
+    def _build_context_snapshot(self, address: int) -> Dict[str, Any]:
+        """Build a context snapshot for a specific address on IDA's main thread."""
+        self._current_offset = address
+        return {
             "offset": self._current_offset,
             "offset_hex": f"0x{self._current_offset:x}",
             "current_view_level": self.get_current_view_level().value,
@@ -86,7 +81,40 @@ class BinaryContextService:
             "view_capabilities": self._get_view_capabilities(),
         }
 
-        return context
+    def get_current_context(self) -> Dict[str, Any]:
+        """Get complete context snapshot for current state"""
+        if not _IN_IDA:
+            return {"error": "Not running inside IDA Pro"}
+
+        context_holder = [{"error": "Failed to read current IDA context"}]
+
+        def _do():
+            try:
+                current_ea = ida_kernwin.get_screen_ea()
+                context_holder[0] = self._build_context_snapshot(current_ea)
+            except Exception as e:
+                context_holder[0] = {"error": f"Failed to get current context: {e}"}
+
+        execute_on_main_thread(_do)
+        return context_holder[0]
+
+    def get_context_for_address(self, address: int) -> Dict[str, Any]:
+        """Get complete context snapshot for an explicit address."""
+        if not _IN_IDA:
+            return {"error": "Not running inside IDA Pro"}
+        if address is None:
+            return {"error": "No address provided"}
+
+        context_holder = [{"error": f"Failed to read IDA context at 0x{address:x}"}]
+
+        def _do():
+            try:
+                context_holder[0] = self._build_context_snapshot(address)
+            except Exception as e:
+                context_holder[0] = {"error": f"Failed to get context for 0x{address:x}: {e}"}
+
+        execute_on_main_thread(_do)
+        return context_holder[0]
 
     def _get_binary_info(self) -> Dict[str, Any]:
         """Extract basic binary metadata from IDA"""

--- a/src/services/function_summary_service.py
+++ b/src/services/function_summary_service.py
@@ -62,9 +62,9 @@ class FunctionSummaryService:
             log.log_warn("No context service available for prompt generation")
             return None
 
-        # Get context for the function
-        self._context_service.set_current_offset(func_address)
-        context = self._context_service.get_current_context()
+        # Build context for the target function explicitly. The semantic-analysis
+        # worker runs off the UI thread, so screen-EA-based lookups are unreliable.
+        context = self._context_service.get_context_for_address(func_address)
 
         if context.get("error"):
             log.log_warn(f"Context error: {context['error']}")

--- a/src/services/llm_providers/openai_oauth_provider.py
+++ b/src/services/llm_providers/openai_oauth_provider.py
@@ -567,6 +567,30 @@ class OpenAIOAuthProvider(BaseLLMProvider):
                 tool_calls.append(tool_call)
                 finish_reason = "tool_calls"
 
+        # Some Responses API completions only surface assistant text via streamed
+        # output_text delta events and leave the final response.output empty.
+        if not text_content:
+            text_content = response_data.get("_collected_text", "")
+
+        for item in response_data.get("_collected_tool_calls", []):
+            try:
+                arguments = item.get("arguments", "{}")
+                if isinstance(arguments, str):
+                    arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                arguments = {}
+
+            call_id = item.get("call_id", item.get("id", ""))
+            if any(existing.id == call_id for existing in tool_calls):
+                continue
+
+            tool_calls.append(ToolCall(
+                id=call_id,
+                name=item.get("name", ""),
+                arguments=arguments
+            ))
+            finish_reason = "tool_calls"
+
         # Check status for finish reason
         status = response_data.get("status", "completed")
         if status == "incomplete":
@@ -588,6 +612,8 @@ class OpenAIOAuthProvider(BaseLLMProvider):
             Complete response data dict
         """
         final_response = {}
+        collected_text_parts: List[str] = []
+        collected_tool_calls: List[Dict[str, Any]] = []
 
         async for line in response.content:
             line = line.decode('utf-8').strip()
@@ -609,9 +635,23 @@ class OpenAIOAuthProvider(BaseLLMProvider):
 
                 event_type = event_data.get("type", "")
 
+                if event_type == "response.output_text.delta":
+                    delta_text = event_data.get("delta", "")
+                    if delta_text:
+                        collected_text_parts.append(delta_text)
+                elif event_type == "response.output_item.done":
+                    item = event_data.get("item", {})
+                    if item.get("type") == "function_call":
+                        collected_tool_calls.append(item)
+
                 # Capture the final response
                 if event_type in ("response.completed", "response.done"):
                     final_response = event_data.get("response", {})
+
+        if collected_text_parts:
+            final_response["_collected_text"] = "".join(collected_text_parts)
+        if collected_tool_calls:
+            final_response["_collected_tool_calls"] = collected_tool_calls
 
         return final_response
 


### PR DESCRIPTION
## Summary
- fix semantic-analysis prompt generation to use explicit function address context instead of the live screen EA
- preserve streamed text and tool calls in the OpenAI OAuth non-streaming Responses path so background jobs receive final content
- keep the fix scoped to the semantic-analysis failure path without including unrelated branch work

## Verification
- python -m compileall src
- live OpenAI OAuth probe: non-streaming chat_completion now returns content instead of an empty string
- manual IDA check: Semantic Analysis now produces summaries