### PR TITLE
feat(bedrock): add native AWS Bedrock provider via Converse API

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ IDAssist supports the following provider types:
 | `anthropic_platform` | API Key | Anthropic API direct |
 | `anthropic_oauth` | OAuth (browser) | Browser-based authentication |
 | `anthropic_claude_cli` | Local CLI | Uses the `claude` CLI binary |
+| `bedrock` | AWS Credentials | Direct AWS Bedrock Converse API |
 | `openai_platform` | API Key | OpenAI API direct |
 | `openai_oauth` | OAuth (browser) | Browser-based authentication |
 | `ollama` | None (local) | Self-hosted models |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,6 +116,28 @@ Use LiteLLM to route through multiple providers with a single endpoint.
    - **API Key:** your proxy key (if required)
 3. Click **Save**, then set as **Active Provider**
 
+### Option 5: AWS Bedrock
+
+Use AWS Bedrock Converse API directly via boto3. Requires an AWS account with Bedrock access.
+
+1. Ensure you have **AWS credentials** configured (env vars, `~/.aws/credentials`, or IAM role)
+2. In IDAssist Settings, click **Add**:
+   - **Name:** `AWS Bedrock`
+   - **Type:** `bedrock`
+   - **Model:** e.g., `anthropic.claude-sonnet-4-6`
+   - **AWS Region:** e.g., `us-east-1`
+   - **AWS Profile:** (optional) named profile from credentials file
+   - **AWS Access Key / Secret Key:** (optional) overrides credential chain
+3. Click **Save**, then set as **Active Provider**
+
+> Available Bedrock model IDs: [docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html)
+>
+> **Note:** AWS Bedrock has its own service quotas (requests per minute, tokens per minute per model) and separate pricing per model. Check your quota limits and costs at:
+> - Pricing: [aws.amazon.com/bedrock/pricing](https://aws.amazon.com/bedrock/pricing/)
+> - Quotas: [docs.aws.amazon.com/bedrock/latest/userguide/quotas.html](https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html)
+>
+> It is your responsibility to monitor usage and ensure you operate within your allocated quotas.
+
 ### Setting the Active Provider
 
 After adding a provider, select it from the **Active Provider** dropdown in the Settings tab. Only one provider is active at a time. You can switch providers at any time — the active provider is used for all Explain, Query, and Actions operations.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto3
 openai
 anthropic
 pysqlite3

--- a/src/controllers/settings_controller.py
+++ b/src/controllers/settings_controller.py
@@ -67,6 +67,7 @@ def validate_provider_test_config(provider_config):
         return f"Provider '{provider_name}' has no model configured."
 
     if (provider_type != ProviderType.ANTHROPIC_CLI and
+            provider_type != ProviderType.BEDROCK and
             not ProviderType.uses_oauth(provider_type) and
             not provider_config.get('url', '').strip()):
         return f"Provider '{provider_name}' has no URL configured."
@@ -99,6 +100,7 @@ def get_provider_worker_timeout_seconds(provider_config):
 def supports_live_model_discovery(provider_type):
     """Check whether a provider type supports live model discovery."""
     return provider_type in {
+        ProviderType.BEDROCK,
         ProviderType.OPENAI_PLATFORM,
         ProviderType.XAI_PLATFORM,
         ProviderType.LMSTUDIO,
@@ -491,7 +493,8 @@ class ProviderDialog(QDialog):
     def setup_ui(self):
         self.setWindowTitle("LLM Provider" if not self.provider_data else f"Edit {self.provider_data.get('name', 'Provider')}")
         self.setModal(True)
-        self.resize(450, 430)
+        self.setMinimumWidth(480)
+        self.resize(480, 650)
 
         layout = QVBoxLayout()
 
@@ -571,6 +574,48 @@ class ProviderDialog(QDialog):
         layout.addWidget(self.oauth_note_label)
         self.oauth_note_label.setVisible(False)
 
+        # AWS Bedrock config
+        self.bedrock_note_label = QLabel(
+            "Uses AWS credentials via boto3 credential chain (env vars, ~/.aws/credentials, IAM role).\n"
+            "See: https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html"
+        )
+        self.bedrock_note_label.setStyleSheet("color: #666; font-style: italic; margin-top: 10px;")
+        self.bedrock_note_label.setWordWrap(True)
+        layout.addWidget(self.bedrock_note_label)
+
+        self.aws_region_label = QLabel("AWS Region:")
+        layout.addWidget(self.aws_region_label)
+        self.aws_region_edit = QLineEdit()
+        self.aws_region_edit.setPlaceholderText("us-east-1")
+        layout.addWidget(self.aws_region_edit)
+
+        self.aws_profile_label = QLabel("AWS Profile (optional):")
+        layout.addWidget(self.aws_profile_label)
+        self.aws_profile_edit = QLineEdit()
+        self.aws_profile_edit.setPlaceholderText("default")
+        layout.addWidget(self.aws_profile_edit)
+
+        self.aws_access_key_label = QLabel("AWS Access Key ID (optional):")
+        layout.addWidget(self.aws_access_key_label)
+        self.aws_access_key_edit = QLineEdit()
+        layout.addWidget(self.aws_access_key_edit)
+
+        self.aws_secret_key_label = QLabel("AWS Secret Access Key (optional):")
+        layout.addWidget(self.aws_secret_key_label)
+        self.aws_secret_key_edit = QLineEdit()
+        self.aws_secret_key_edit.setEchoMode(QLineEdit.Password)
+        layout.addWidget(self.aws_secret_key_edit)
+
+        self.bedrock_note_label.setVisible(False)
+        self.aws_region_label.setVisible(False)
+        self.aws_region_edit.setVisible(False)
+        self.aws_profile_label.setVisible(False)
+        self.aws_profile_edit.setVisible(False)
+        self.aws_access_key_label.setVisible(False)
+        self.aws_access_key_edit.setVisible(False)
+        self.aws_secret_key_label.setVisible(False)
+        self.aws_secret_key_edit.setVisible(False)
+
         # Disable TLS
         self.disable_tls_check = QCheckBox("Disable TLS Verification")
         layout.addWidget(self.disable_tls_check)
@@ -647,6 +692,11 @@ class ProviderDialog(QDialog):
             self.disable_tls_check.setChecked(self.provider_data.get('disable_tls', False))
             self.bypass_proxy_check.setChecked(self.provider_data.get('bypass_proxy', False))
 
+            self.aws_region_edit.setText(self.provider_data.get('aws_region', ''))
+            self.aws_profile_edit.setText(self.provider_data.get('aws_profile', ''))
+            self.aws_access_key_edit.setText(self.provider_data.get('aws_access_key_id', ''))
+            self.aws_secret_key_edit.setText(self.provider_data.get('aws_secret_access_key', ''))
+
     def get_provider_data(self):
         """Get the provider data from the form"""
         return {
@@ -658,7 +708,11 @@ class ProviderDialog(QDialog):
             'timeout': self.timeout_spin.value(),
             'api_key': self.key_edit.text(),
             'disable_tls': self.disable_tls_check.isChecked(),
-            'bypass_proxy': self.bypass_proxy_check.isChecked()
+            'bypass_proxy': self.bypass_proxy_check.isChecked(),
+            'aws_region': self.aws_region_edit.text().strip(),
+            'aws_profile': self.aws_profile_edit.text().strip(),
+            'aws_access_key_id': self.aws_access_key_edit.text(),
+            'aws_secret_access_key': self.aws_secret_key_edit.text(),
         }
 
     def _get_current_model_text(self):
@@ -841,6 +895,17 @@ class ProviderDialog(QDialog):
 
                 if is_litellm:
                     self.update_litellm_metadata()
+
+                is_bedrock = provider_type == ProviderType.BEDROCK
+                self.bedrock_note_label.setVisible(is_bedrock)
+                self.aws_region_label.setVisible(is_bedrock)
+                self.aws_region_edit.setVisible(is_bedrock)
+                self.aws_profile_label.setVisible(is_bedrock)
+                self.aws_profile_edit.setVisible(is_bedrock)
+                self.aws_access_key_label.setVisible(is_bedrock)
+                self.aws_access_key_edit.setVisible(is_bedrock)
+                self.aws_secret_key_label.setVisible(is_bedrock)
+                self.aws_secret_key_edit.setVisible(is_bedrock)
 
                 is_claude_code = provider_type == ProviderType.ANTHROPIC_CLI
                 self.claude_code_note_label.setVisible(is_claude_code)

--- a/src/services/llm_providers/bedrock_provider.py
+++ b/src/services/llm_providers/bedrock_provider.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+
+"""Bedrock Provider - Implementation for AWS Bedrock Converse API."""
+
+import json
+import time
+from typing import List, Dict, Any, AsyncGenerator, Optional, Callable
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError, BotoCoreError
+except ImportError:
+    raise ImportError("boto3 package not available. Install with: pip install boto3")
+
+from .base_provider import (
+    BaseLLMProvider, APIProviderError, AuthenticationError,
+    RateLimitError, NetworkError
+)
+from ..models.llm_models import (
+    ChatRequest, ChatResponse, EmbeddingRequest, EmbeddingResponse,
+    ChatMessage, MessageRole, ToolCall, Usage, ProviderCapabilities,
+    ProviderModelDiscoveryResult
+)
+from ..models.provider_types import ProviderType
+from ..models.reasoning_models import ReasoningConfig
+
+from src.ida_compat import log
+
+
+class BedrockProvider(BaseLLMProvider):
+    """AWS Bedrock provider via the Converse / ConverseStream API.
+
+    Authenticates via boto3's credential chain: environment variables,
+    AWS credentials file, IAM role, or explicit access key/secret key.
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize Bedrock provider."""
+        super().__init__(config)
+
+        self.aws_region = config.get('aws_region', 'us-east-1')
+        self.aws_profile = config.get('aws_profile', '')
+        self.aws_access_key_id = config.get('aws_access_key_id', '')
+        self.aws_secret_access_key = config.get('aws_secret_access_key', '')
+
+        self.validate_config()
+
+        log.log_info(
+            f"Bedrock provider initialized with region={self.aws_region}, "
+            f"model={self.model}"
+        )
+
+    def validate_config(self):
+        """Validate provider configuration - relaxed for Bedrock."""
+        if not self.name:
+            raise ValueError("Provider name is required")
+        if not self.model:
+            raise ValueError("Model is required")
+        if not self.aws_region:
+            raise ValueError("AWS region is required")
+
+    def _create_client(self):
+        """Create a boto3 bedrock-runtime client.
+
+        Uses the configured credential chain: explicit keys take precedence,
+        then named profile, then default boto3 chain.
+        """
+        session_kwargs = {}
+        if self.aws_profile:
+            session_kwargs['profile_name'] = self.aws_profile
+
+        session = boto3.Session(**session_kwargs)
+
+        client_kwargs = {
+            'region_name': self.aws_region,
+        }
+        if self.aws_access_key_id and self.aws_secret_access_key:
+            client_kwargs['aws_access_key_id'] = self.aws_access_key_id
+            client_kwargs['aws_secret_access_key'] = self.aws_secret_access_key
+
+        return session.client('bedrock-runtime', **client_kwargs)
+
+    @staticmethod
+    def _prepare_messages(messages: List[ChatMessage]):
+        """Convert internal ChatMessage list to Bedrock Converse format.
+
+        Bedrock Converse API expects:
+            messages: [{"role": "user"|"assistant", "content": [{"text": "..."}]}]
+            system: [{"text": "..."}] (separate from messages)
+        """
+        converse_messages = []
+        system_content = None
+
+        for msg in messages:
+            if msg.role == MessageRole.SYSTEM:
+                if msg.content:
+                    system_content = [{"text": msg.content}]
+                continue
+
+            role = "user" if msg.role == MessageRole.USER else "assistant"
+
+            content_blocks = []
+            if msg.content:
+                content_blocks.append({"text": msg.content})
+
+            if msg.tool_calls:
+                for tc in msg.tool_calls:
+                    content_blocks.append({
+                        "toolUse": {
+                            "toolUseId": tc.id,
+                            "name": tc.name,
+                            "input": tc.arguments
+                        }
+                    })
+
+            if msg.tool_call_id:
+                content_blocks.append({
+                    "toolResult": {
+                        "toolUseId": msg.tool_call_id,
+                        "content": [{"text": msg.content or ""}]
+                    }
+                })
+
+            converse_messages.append({
+                "role": role,
+                "content": content_blocks
+            })
+
+        return converse_messages, system_content
+
+    @staticmethod
+    def _build_inference_config(request: ChatRequest) -> Dict[str, Any]:
+        """Build inferenceConfig dict from ChatRequest."""
+        config = {}
+        if request.max_tokens:
+            config['maxTokens'] = request.max_tokens
+        if request.temperature is not None:
+            config['temperature'] = request.temperature
+        if request.top_p is not None:
+            config['topP'] = request.top_p
+        if request.stop:
+            stops = request.stop if isinstance(request.stop, list) else [request.stop]
+            config['stopSequences'] = stops
+        return config
+
+    @staticmethod
+    def _build_tool_config(tools: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Build Bedrock toolConfig from OpenAI-format tool definitions."""
+        bedrock_tools = []
+        for tool in tools:
+            function_def = {
+                "name": tool["function"]["name"],
+                "description": tool["function"].get("description", ""),
+            }
+            if "parameters" in tool["function"]:
+                function_def["parameters"] = tool["function"]["parameters"]
+
+            bedrock_tools.append({
+                "toolSpec": {
+                    "name": function_def["name"],
+                    "description": function_def["description"],
+                    "inputSchema": {
+                        "json": function_def.get("parameters", {"type": "object"})
+                    }
+                }
+            })
+
+        return {"tools": bedrock_tools}
+
+    @staticmethod
+    def _parse_converse_response(response: Dict[str, Any]) -> tuple:
+        """Parse a Converse API response into content and tool_calls."""
+        content = ""
+        tool_calls = []
+
+        output = response.get('output', {})
+        message = output.get('message', {})
+        content_blocks = message.get('content', [])
+
+        for block in content_blocks:
+            if 'text' in block:
+                if content:
+                    content += "\n"
+                content += block['text']
+            elif 'toolUse' in block:
+                tool_use = block['toolUse']
+                tc = ToolCall(
+                    id=tool_use['toolUseId'],
+                    name=tool_use['name'],
+                    arguments=tool_use.get('input', {})
+                )
+                tool_calls.append(tc)
+
+        stop_reason = response.get('stopReason', 'end_turn')
+        finish_reason_map = {
+            'end_turn': 'stop',
+            'tool_use': 'tool_calls',
+            'max_tokens': 'length',
+            'content_filtered': 'content_filter',
+            'stop_sequence': 'stop',
+        }
+        finish_reason = finish_reason_map.get(stop_reason, stop_reason)
+
+        usage_info = response.get('usage', {})
+        usage = Usage(
+            prompt_tokens=usage_info.get('inputTokens', 0),
+            completion_tokens=usage_info.get('outputTokens', 0),
+            total_tokens=(
+                usage_info.get('inputTokens', 0) +
+                usage_info.get('outputTokens', 0)
+            )
+        )
+
+        return content, tool_calls, finish_reason, usage
+
+    async def chat_completion(
+        self,
+        request: ChatRequest,
+        native_message_callback: Optional[Callable[[Dict[str, Any], ProviderType], None]] = None
+    ) -> ChatResponse:
+        """Generate non-streaming chat completion with rate limit retry."""
+        log.log_info(
+            f"Bedrock chat completion for {self.model} "
+            f"with {len(request.messages)} messages"
+        )
+        return await self._with_rate_limit_retry(
+            self._chat_completion_impl, request, native_message_callback
+        )
+
+    async def _chat_completion_impl(
+        self,
+        request: ChatRequest,
+        native_message_callback: Optional[Callable[[Dict[str, Any], ProviderType], None]] = None
+    ) -> ChatResponse:
+        """Internal implementation of chat completion via Converse API."""
+        try:
+            messages, system_prompt = self._prepare_messages(request.messages)
+
+            converse_kwargs = {
+                'modelId': self.model,
+                'messages': messages,
+                'inferenceConfig': self._build_inference_config(request),
+            }
+
+            if system_prompt:
+                converse_kwargs['system'] = system_prompt
+
+            if request.tools:
+                converse_kwargs['toolConfig'] = self._build_tool_config(request.tools)
+
+            client = self._create_client()
+            response = client.converse(**converse_kwargs)
+
+            content, tool_calls, finish_reason, usage = self._parse_converse_response(response)
+
+            if native_message_callback:
+                native_message = {
+                    "role": "assistant",
+                    "content": content,
+                    "tool_calls": [
+                        {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+                        for tc in tool_calls
+                    ] if tool_calls else [],
+                    "model": self.model,
+                    "stopReason": response.get('stopReason', ''),
+                }
+                native_message_callback(native_message, self.get_provider_type())
+
+            return ChatResponse(
+                content=content,
+                model=self.model,
+                usage=usage,
+                tool_calls=tool_calls if tool_calls else None,
+                finish_reason=finish_reason,
+            )
+
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            error_message = e.response['Error']['Message']
+            if error_code in ('AccessDeniedException', 'UnrecognizedClientException'):
+                raise AuthenticationError(
+                    f"AWS authentication failed: {error_message}"
+                )
+            elif error_code == 'ThrottlingException':
+                raise RateLimitError(
+                    f"AWS Bedrock throttling: {error_message}"
+                )
+            elif error_code == 'ModelTimeoutException':
+                raise APIProviderError(
+                    f"Model request timed out: {error_message}"
+                )
+            elif error_code == 'ModelNotReadyException':
+                raise APIProviderError(
+                    f"Model not ready: {error_message}"
+                )
+            raise APIProviderError(
+                f"AWS Bedrock API error ({error_code}): {error_message}"
+            )
+        except BotoCoreError as e:
+            raise NetworkError(f"AWS SDK error: {e}")
+        except Exception as e:
+            log.log_error(f"Chat completion failed: {e}")
+            raise APIProviderError(
+                f"Unexpected error during chat completion: {e}"
+            )
+
+    async def chat_completion_stream(
+        self,
+        request: ChatRequest,
+        native_message_callback: Optional[Callable[[Dict[str, Any], ProviderType], None]] = None
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Generate streaming chat completion with rate limit retry."""
+        log.log_info(
+            f"Bedrock streaming completion for {self.model} "
+            f"with {len(request.messages)} messages"
+        )
+        async for response in self._with_rate_limit_retry_stream(
+            self._chat_completion_stream_impl, request, native_message_callback
+        ):
+            yield response
+
+    async def _chat_completion_stream_impl(
+        self,
+        request: ChatRequest,
+        native_message_callback: Optional[Callable[[Dict[str, Any], ProviderType], None]] = None
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Internal implementation of streaming via ConverseStream API."""
+        accumulated_content = ""
+        accumulated_tool_calls = []
+        response_id = None
+        response_model = self.model
+        input_token_count = 0
+        output_token_count = 0
+        stop_reason = "stop"
+
+        try:
+            messages, system_prompt = self._prepare_messages(request.messages)
+
+            converse_kwargs = {
+                'modelId': self.model,
+                'messages': messages,
+                'inferenceConfig': self._build_inference_config(request),
+            }
+
+            if system_prompt:
+                converse_kwargs['system'] = system_prompt
+
+            if request.tools:
+                converse_kwargs['toolConfig'] = self._build_tool_config(request.tools)
+
+            client = self._create_client()
+            streaming_response = client.converse_stream(**converse_kwargs)
+            stream = streaming_response.get('stream', [])
+
+            for event in stream:
+                event_type = list(event.keys())[0] if event else None
+
+                if event_type == 'messageStart':
+                    msg = event['messageStart']
+                    role = msg.get('role', 'assistant')
+                    response_id = msg.get('messageId')
+
+                elif event_type == 'contentBlockDelta':
+                    delta = event['contentBlockDelta']
+                    delta_obj = delta.get('delta', {})
+
+                    if 'text' in delta_obj:
+                        text = delta_obj['text']
+                        accumulated_content += text
+                        yield ChatResponse(
+                            content=text,
+                            model=response_model,
+                            usage=Usage(0, 0, 0),
+                            is_streaming=True,
+                            finish_reason="incomplete",
+                            response_id=response_id,
+                        )
+
+                    elif 'toolUse' in delta_obj:
+                        pass
+
+                elif event_type == 'contentBlockStart':
+                    start = event['contentBlockStart']
+                    start_obj = start.get('start', {})
+
+                    if 'toolUse' in start_obj:
+                        tool_use_start = start_obj['toolUse']
+                        current_tool = ToolCall(
+                            id=tool_use_start.get('toolUseId', ''),
+                            name=tool_use_start.get('name', ''),
+                            arguments={}
+                        )
+                        accumulated_tool_calls.append(current_tool)
+
+                elif event_type == 'messageStop':
+                    stop_data = event['messageStop']
+                    stop_reason = stop_data.get('stopReason', 'end_turn')
+
+                elif event_type == 'metadata':
+                    metadata = event['metadata']
+                    usage_info = metadata.get('usage', {})
+                    input_token_count = usage_info.get('inputTokens', 0)
+                    output_token_count = usage_info.get('outputTokens', 0)
+
+            finish_reason_map = {
+                'end_turn': 'stop',
+                'tool_use': 'tool_calls',
+                'max_tokens': 'length',
+                'content_filtered': 'content_filter',
+                'stop_sequence': 'stop',
+            }
+            mapped_stop_reason = finish_reason_map.get(stop_reason, stop_reason)
+
+            usage = Usage(
+                prompt_tokens=input_token_count,
+                completion_tokens=output_token_count,
+                total_tokens=input_token_count + output_token_count,
+            )
+
+            yield ChatResponse(
+                content="",
+                model=response_model,
+                usage=usage,
+                tool_calls=accumulated_tool_calls if accumulated_tool_calls else None,
+                finish_reason=mapped_stop_reason,
+                is_streaming=False,
+                response_id=response_id,
+            )
+
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            error_message = e.response['Error']['Message']
+            if error_code in ('AccessDeniedException', 'UnrecognizedClientException'):
+                raise AuthenticationError(
+                    f"AWS authentication failed: {error_message}"
+                )
+            elif error_code == 'ThrottlingException':
+                raise RateLimitError(
+                    f"AWS Bedrock throttling: {error_message}"
+                )
+            raise APIProviderError(
+                f"AWS Bedrock API error ({error_code}): {error_message}"
+            )
+        except BotoCoreError as e:
+            raise NetworkError(f"AWS SDK error: {e}")
+        except Exception as e:
+            log.log_error(f"Streaming chat completion failed: {e}")
+            raise APIProviderError(
+                f"Unexpected error during streaming: {e}"
+            )
+
+    async def generate_embeddings(self, request: EmbeddingRequest) -> EmbeddingResponse:
+        """Generate text embeddings via Bedrock.
+
+        Not supported via Converse API. Use Amazon Titan models via
+        InvokeModel for embeddings.
+        """
+        raise NotImplementedError(
+            "Embeddings not supported via Bedrock Converse API. "
+            "Use LiteLLM provider with Titan embedding models."
+        )
+
+    async def test_connection(self) -> bool:
+        """Test connectivity by listing available foundation models."""
+        try:
+            session_kwargs = {}
+            if self.aws_profile:
+                session_kwargs['profile_name'] = self.aws_profile
+
+            session = boto3.Session(**session_kwargs)
+            client_kwargs = {'region_name': self.aws_region}
+            if self.aws_access_key_id and self.aws_secret_access_key:
+                client_kwargs['aws_access_key_id'] = self.aws_access_key_id
+                client_kwargs['aws_secret_access_key'] = self.aws_secret_access_key
+
+            client = session.client('bedrock', **client_kwargs)
+
+            response = client.list_foundation_models(
+                byInferenceType='ON_DEMAND'
+            )
+
+            model_summaries = response.get('modelSummaries', [])
+            log.log_info(
+                f"AWS Bedrock connection successful: "
+                f"{len(model_summaries)} models available"
+            )
+            return True
+
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            log.log_error(
+                f"AWS Bedrock connection failed ({error_code}): "
+                f"{e.response['Error']['Message']}"
+            )
+            return False
+        except BotoCoreError as e:
+            log.log_error(f"AWS SDK connection failed: {e}")
+            return False
+        except Exception as e:
+            log.log_error(f"Bedrock connection test failed: {e}")
+            return False
+
+    def get_capabilities(self) -> ProviderCapabilities:
+        """Get provider capabilities for Bedrock Converse API."""
+        return ProviderCapabilities(
+            supports_chat=True,
+            supports_streaming=True,
+            supports_tools=True,
+            supports_embeddings=False,
+            supports_vision=False,
+            supports_model_discovery=True,
+            max_tokens=8192,
+            models=[
+                "anthropic.claude-sonnet-4-6",
+                "anthropic.claude-haiku-4-5",
+                "anthropic.claude-opus-4-5",
+                "amazon.nova-pro-v1:0",
+                "amazon.nova-lite-v1:0",
+                "meta.llama3-3-70b-instruct-v1:0",
+            ],
+        )
+
+    def get_provider_type(self) -> ProviderType:
+        """Get provider type enum value."""
+        return ProviderType.BEDROCK
+
+    def prepare_tool_enabled_request(
+        self,
+        request: ChatRequest,
+        tools: List[Dict[str, Any]]
+    ) -> ChatRequest:
+        """Prepare request with tool definitions enabled.
+
+        Bedrock Converse API handles tools via toolConfig rather than
+        embedding them in the message body.
+        """
+        if not self.supports_tools():
+            return request
+
+        tool_request = ChatRequest(
+            messages=request.messages,
+            model=request.model,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            top_p=request.top_p,
+            stream=request.stream,
+            tools=tools,
+            tool_choice=request.tool_choice or "auto",
+            stop=request.stop,
+            presence_penalty=request.presence_penalty,
+            frequency_penalty=request.frequency_penalty,
+            user=request.user,
+        )
+        return tool_request
+
+    def format_tool_results_for_continuation(
+        self,
+        tool_calls: List[ToolCall],
+        tool_results: List[str]
+    ) -> List[Dict[str, Any]]:
+        """Format tool results for Bedrock Converse continuation."""
+        messages = []
+        for tool_call, result in zip(tool_calls, tool_results):
+            messages.append({
+                "role": "tool",
+                "content": result,
+                "tool_call_id": tool_call.id,
+                "name": tool_call.name,
+            })
+        return messages
+
+
+class BedrockProviderFactory:
+    """Factory for creating Bedrock provider instances."""
+
+    def create_provider(self, config: Dict[str, Any]) -> BedrockProvider:
+        """Create Bedrock provider instance."""
+        return BedrockProvider(config)
+
+    def supports_provider_type(self, provider_type: ProviderType) -> bool:
+        """Check if this factory supports the provider type."""
+        return provider_type == ProviderType.BEDROCK

--- a/src/services/llm_providers/provider_factory.py
+++ b/src/services/llm_providers/provider_factory.py
@@ -117,6 +117,16 @@ class LLMProviderFactory:
         except ImportError:
             pass  # Anthropic Platform API provider not available
 
+        # AWS Bedrock provider
+        try:
+            from .bedrock_provider import BedrockProviderFactory
+            self.register_factory(
+                ProviderType.BEDROCK,
+                BedrockProviderFactory()
+            )
+        except ImportError:
+            pass  # AWS Bedrock provider not available
+
         # LiteLLM proxy provider
         try:
             self.register_factory(

--- a/src/services/migrations/__init__.py
+++ b/src/services/migrations/__init__.py
@@ -5,6 +5,7 @@ from .add_reasoning_effort import migrate_add_reasoning_effort
 from .add_litellm_configs import migrate_add_litellm_configs
 from .add_provider_timeout import migrate_add_provider_timeout
 from .add_mcp_stdio_fields import migrate_add_mcp_stdio_fields
+from .add_aws_bedrock_config import migrate_add_aws_bedrock_config
 from .migrate_provider_type_names import migrate_provider_type_names
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     'migrate_add_litellm_configs',
     'migrate_add_provider_timeout',
     'migrate_add_mcp_stdio_fields',
+    'migrate_add_aws_bedrock_config',
     'migrate_provider_type_names'
 ]

--- a/src/services/migrations/add_aws_bedrock_config.py
+++ b/src/services/migrations/add_aws_bedrock_config.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+"""Migration: Add AWS Bedrock configuration fields to llm_providers table."""
+
+import sqlite3
+
+from src.ida_compat import log
+
+
+def migrate_add_aws_bedrock_config(db_path: str):
+    """Add AWS Bedrock-specific columns to the llm_providers table.
+
+    New fields:
+    - aws_region: AWS region for Bedrock endpoint (e.g., us-east-1)
+    - aws_profile: Named AWS profile from credentials file
+    - aws_access_key_id: AWS access key (optional, uses boto3 chain otherwise)
+    - aws_secret_access_key: AWS secret key (optional, uses boto3 chain otherwise)
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+
+        cursor.execute("PRAGMA table_info(llm_providers)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        changes_made = False
+
+        if 'aws_region' not in columns:
+            cursor.execute('''
+                ALTER TABLE llm_providers
+                ADD COLUMN aws_region TEXT DEFAULT ''
+            ''')
+            log.log_info("Added aws_region column to llm_providers")
+            changes_made = True
+
+        if 'aws_profile' not in columns:
+            cursor.execute('''
+                ALTER TABLE llm_providers
+                ADD COLUMN aws_profile TEXT DEFAULT ''
+            ''')
+            log.log_info("Added aws_profile column to llm_providers")
+            changes_made = True
+
+        if 'aws_access_key_id' not in columns:
+            cursor.execute('''
+                ALTER TABLE llm_providers
+                ADD COLUMN aws_access_key_id TEXT DEFAULT ''
+            ''')
+            log.log_info("Added aws_access_key_id column to llm_providers")
+            changes_made = True
+
+        if 'aws_secret_access_key' not in columns:
+            cursor.execute('''
+                ALTER TABLE llm_providers
+                ADD COLUMN aws_secret_access_key TEXT DEFAULT ''
+            ''')
+            log.log_info("Added aws_secret_access_key column to llm_providers")
+            changes_made = True
+
+        if changes_made:
+            conn.commit()
+            log.log_info("AWS Bedrock config migration completed successfully")
+        else:
+            log.log_info("AWS Bedrock columns already exist, skipping migration")
+
+    except Exception as e:
+        conn.rollback()
+        log.log_error(f"AWS Bedrock migration failed: {e}")
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import os
+    from src.ida_compat import get_user_data_dir
+
+    db_path = os.path.join(get_user_data_dir(), 'settings.db')
+    if os.path.exists(db_path):
+        migrate_add_aws_bedrock_config(db_path)
+    else:
+        log.log_error("Settings database not found")

--- a/src/services/models/provider_types.py
+++ b/src/services/models/provider_types.py
@@ -40,6 +40,9 @@ class ProviderType(Enum):
     OPENAI_OAUTH = "openai_oauth"             # OAuth (ChatGPT Pro/Plus subscription)
     OPENAI_PLATFORM = "openai_platform"       # Platform API (direct API key)
 
+    # AWS Bedrock provider
+    BEDROCK = "bedrock"                       # AWS Bedrock Converse API
+
     # X.ai providers
     XAI_PLATFORM = "xai_platform"             # Platform API (direct API key)
 
@@ -50,6 +53,8 @@ class ProviderType(Enum):
             # Anthropic
             cls.ANTHROPIC_CLI: "Anthropic CLI (Claude Code)",
             cls.ANTHROPIC_PLATFORM: "Anthropic Platform API",
+            # AWS Bedrock
+            cls.BEDROCK: "AWS Bedrock",
             # Gemini
             cls.GEMINI_OAUTH: "Gemini OAuth (Gemini CLI)",
             cls.GEMINI_PLATFORM: "Gemini Platform API",
@@ -72,6 +77,8 @@ class ProviderType(Enum):
             # Anthropic
             cls.ANTHROPIC_CLI: "",  # CLI-based, no URL needed
             cls.ANTHROPIC_PLATFORM: "https://api.anthropic.com",
+            # AWS Bedrock
+            cls.BEDROCK: "",  # Uses boto3 client, no URL needed
             # Gemini
             cls.GEMINI_OAUTH: "https://cloudcode-pa.googleapis.com",
             cls.GEMINI_PLATFORM: "https://generativelanguage.googleapis.com/v1beta/openai/",
@@ -98,6 +105,12 @@ class ProviderType(Enum):
             cls.ANTHROPIC_PLATFORM: [
                 "claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022",
                 "claude-3-opus-20240229", "claude-3-sonnet-20240229"
+            ],
+            # AWS Bedrock
+            cls.BEDROCK: [
+                "anthropic.claude-sonnet-4-6", "anthropic.claude-haiku-4-5",
+                "anthropic.claude-opus-4-5", "amazon.nova-pro-v1:0",
+                "amazon.nova-lite-v1:0", "meta.llama3-3-70b-instruct-v1:0",
             ],
             # Gemini
             cls.GEMINI_OAUTH: [
@@ -153,6 +166,7 @@ class ProviderType(Enum):
         return provider_type in {
             cls.ANTHROPIC_CLI,       # Via CLI --allowedTools flag
             cls.ANTHROPIC_PLATFORM,  # Full tool calling support
+            cls.BEDROCK,             # Converse API supports tool use
             cls.GEMINI_OAUTH,        # Full tool calling support
             cls.GEMINI_PLATFORM,     # Full tool calling support
             cls.LITELLM,             # Proxies tool calls
@@ -170,6 +184,7 @@ class ProviderType(Enum):
         return provider_type in {
             # Note: ANTHROPIC_CLI does NOT support true streaming
             cls.ANTHROPIC_PLATFORM,
+            cls.BEDROCK,             # ConverseStream API
             cls.GEMINI_OAUTH,
             cls.GEMINI_PLATFORM,
             cls.LITELLM,

--- a/src/services/settings_service.py
+++ b/src/services/settings_service.py
@@ -145,6 +145,7 @@ class SettingsService:
                 migrate_add_litellm_configs,
                 migrate_add_provider_timeout,
                 migrate_add_mcp_stdio_fields,
+                migrate_add_aws_bedrock_config,
                 migrate_provider_type_names
             )
             from .migrations.add_oauth_credentials import migrate_add_oauth_credentials
@@ -157,6 +158,7 @@ class SettingsService:
             migrate_add_oauth_credentials(self._db_path)
             migrate_provider_type_names(self._db_path)
             migrate_add_bypass_proxy(self._db_path)
+            migrate_add_aws_bedrock_config(self._db_path)
         except Exception as e:
             # Migration failures shouldn't prevent plugin loading
             try:
@@ -355,7 +357,9 @@ class SettingsService:
     def add_llm_provider(self, name: str, model: str, url: str, max_tokens: int = 4096,
                         api_key: str = '', disable_tls: bool = False, provider_type: str = 'openai_platform',
                         reasoning_effort: str = 'none', bypass_proxy: bool = False,
-                        timeout: int = DEFAULT_PROVIDER_TIMEOUT_SECONDS) -> int:
+                        timeout: int = DEFAULT_PROVIDER_TIMEOUT_SECONDS,
+                        aws_region: str = '', aws_profile: str = '',
+                        aws_access_key_id: str = '', aws_secret_access_key: str = '') -> int:
         """Add a new LLM provider"""
         model_family = 'unknown'
         is_bedrock = False
@@ -369,9 +373,9 @@ class SettingsService:
                 cursor = conn.cursor()
                 cursor.execute('''
                     INSERT INTO llm_providers
-                    (name, model, url, max_tokens, api_key, disable_tls, provider_type, reasoning_effort, model_family, is_bedrock, litellm_params, timeout, bypass_proxy)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ''', (name, model, url, max_tokens, api_key, disable_tls, provider_type, reasoning_effort, model_family, is_bedrock, '{}', timeout, bypass_proxy))
+                    (name, model, url, max_tokens, api_key, disable_tls, provider_type, reasoning_effort, model_family, is_bedrock, litellm_params, timeout, bypass_proxy, aws_region, aws_profile, aws_access_key_id, aws_secret_access_key)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''', (name, model, url, max_tokens, api_key, disable_tls, provider_type, reasoning_effort, model_family, is_bedrock, '{}', timeout, bypass_proxy, aws_region, aws_profile, aws_access_key_id, aws_secret_access_key))
 
                 provider_id = cursor.lastrowid
                 conn.commit()
@@ -392,7 +396,7 @@ class SettingsService:
             try:
                 cursor = conn.cursor()
                 cursor.execute('''
-                    SELECT id, name, model, url, max_tokens, api_key, disable_tls, provider_type, is_active, reasoning_effort, timeout, bypass_proxy
+                    SELECT id, name, model, url, max_tokens, api_key, disable_tls, provider_type, is_active, reasoning_effort, timeout, bypass_proxy, aws_region, aws_profile, aws_access_key_id, aws_secret_access_key
                     FROM llm_providers ORDER BY name
                 ''')
 
@@ -410,7 +414,11 @@ class SettingsService:
                         'is_active': bool(row[8]),
                         'reasoning_effort': row[9] if len(row) > 9 else 'none',
                         'timeout': row[10] if len(row) > 10 else DEFAULT_PROVIDER_TIMEOUT_SECONDS,
-                        'bypass_proxy': bool(row[11]) if len(row) > 11 else False
+                        'bypass_proxy': bool(row[11]) if len(row) > 11 else False,
+                        'aws_region': row[12] if len(row) > 12 else '',
+                        'aws_profile': row[13] if len(row) > 13 else '',
+                        'aws_access_key_id': row[14] if len(row) > 14 else '',
+                        'aws_secret_access_key': row[15] if len(row) > 15 else '',
                     })
 
                 return providers
@@ -424,7 +432,8 @@ class SettingsService:
         """Update an LLM provider"""
         valid_fields = {'name', 'model', 'url', 'max_tokens', 'api_key', 'disable_tls', 'bypass_proxy',
                         'provider_type', 'is_active', 'reasoning_effort', 'timeout',
-                        'model_family', 'is_bedrock', 'litellm_params'}
+                        'model_family', 'is_bedrock', 'litellm_params',
+                        'aws_region', 'aws_profile', 'aws_access_key_id', 'aws_secret_access_key'}
         update_fields = {k: v for k, v in kwargs.items() if k in valid_fields}
 
         if not update_fields:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for IDAssist."""

--- a/tests/test_bedrock_factory.py
+++ b/tests/test_bedrock_factory.py
@@ -1,0 +1,102 @@
+"""Tests for Bedrock provider factory registration."""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.services.llm_providers.provider_factory import (
+    LLMProviderFactory, get_provider_factory
+)
+from src.services.models.provider_types import ProviderType
+
+
+class TestBedrockFactory(unittest.TestCase):
+    """BedrockProviderFactory registration and creation."""
+
+    def setUp(self):
+        """Create a fresh factory for each test (bypass singleton)."""
+        self.factory = LLMProviderFactory()
+
+    def test_bedrock_is_registered(self):
+        """BEDROCK is registered in the factory."""
+        self.assertTrue(self.factory.is_supported(ProviderType.BEDROCK))
+
+    def test_bedrock_create_provider(self):
+        """Factory creates a BedrockProvider with minimal config."""
+        config = {
+            'name': 'Test Bedrock',
+            'model': 'anthropic.claude-sonnet-4-6',
+            'provider_type': 'bedrock',
+            'aws_region': 'us-east-1',
+        }
+        provider = self.factory.create_provider(config)
+        self.assertIsNotNone(provider)
+        self.assertEqual(provider.get_provider_type(), ProviderType.BEDROCK)
+        self.assertEqual(provider.model, 'anthropic.claude-sonnet-4-6')
+        self.assertEqual(provider.aws_region, 'us-east-1')
+
+    def test_bedrock_create_with_credentials(self):
+        """Factory passes AWS credential config to provider."""
+        config = {
+            'name': 'Test Bedrock Creds',
+            'model': 'anthropic.claude-sonnet-4-6',
+            'provider_type': 'bedrock',
+            'aws_region': 'us-west-2',
+            'aws_profile': 'my-profile',
+            'aws_access_key_id': 'AKIA123',
+            'aws_secret_access_key': 'secret123',
+        }
+        provider = self.factory.create_provider(config)
+        self.assertEqual(provider.aws_region, 'us-west-2')
+        self.assertEqual(provider.aws_profile, 'my-profile')
+        self.assertEqual(provider.aws_access_key_id, 'AKIA123')
+        self.assertEqual(provider.aws_secret_access_key, 'secret123')
+
+    def test_bedrock_factory_supports_type(self):
+        """BedrockProviderFactory only supports BEDROCK."""
+        from src.services.llm_providers.bedrock_provider import BedrockProviderFactory
+        bf = BedrockProviderFactory()
+        self.assertTrue(bf.supports_provider_type(ProviderType.BEDROCK))
+        self.assertFalse(bf.supports_provider_type(ProviderType.OLLAMA))
+
+    def test_global_factory_has_bedrock(self):
+        """Global factory singleton includes BEDROCK."""
+        gf = get_provider_factory()
+        self.assertTrue(gf.is_supported(ProviderType.BEDROCK))
+
+    def test_bedrock_not_in_other_providers(self):
+        """BEDROCK is not mixed into other provider type lookups."""
+        self.assertNotEqual(ProviderType.BEDROCK, ProviderType.LITELLM)
+        self.assertNotEqual(ProviderType.BEDROCK, ProviderType.ANTHROPIC_PLATFORM)
+
+    def test_existing_factories_unchanged(self):
+        """Registered providers can still be created."""
+        supported = self.factory.get_supported_types()
+        self.assertIn(ProviderType.BEDROCK, supported)
+        for pt in supported:
+            config = {
+                'name': f'Test {pt.value}',
+                'model': 'test-model',
+                'provider_type': pt.value,
+                'url': 'http://localhost:9999',
+            }
+            try:
+                provider = self.factory.create_provider(config)
+                self.assertEqual(provider.get_provider_type(), pt)
+            except Exception:
+                pass
+
+    def test_factory_raises_on_missing_config(self):
+        """Factory raises error for missing required config."""
+        from src.services.llm_providers.base_provider import LLMProviderError
+        with self.assertRaises(LLMProviderError):
+            self.factory.create_provider({
+                'provider_type': 'bedrock',
+            })
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_bedrock_migration.py
+++ b/tests/test_bedrock_migration.py
@@ -1,0 +1,150 @@
+"""Tests for AWS Bedrock DB migration - idempotent, adds columns correctly."""
+
+import sys
+import os
+import sqlite3
+import unittest
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.services.migrations.add_aws_bedrock_config import migrate_add_aws_bedrock_config
+
+
+def _create_minimal_db(path):
+    """Create a llm_providers table matching the pre-migration schema."""
+    conn = sqlite3.connect(path)
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS llm_providers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            model TEXT NOT NULL,
+            url TEXT NOT NULL,
+            max_tokens INTEGER DEFAULT 4096,
+            api_key TEXT,
+            disable_tls BOOLEAN DEFAULT 0,
+            provider_type TEXT DEFAULT 'openai_platform',
+            is_active BOOLEAN DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+    conn.execute('''
+        INSERT INTO llm_providers (name, model, url, provider_type)
+        VALUES ('test-ollama', 'llama3.1:8b', 'http://localhost:11434', 'ollama')
+    ''')
+    conn.execute('''
+        INSERT INTO llm_providers (name, model, url, provider_type)
+        VALUES ('test-openai', 'gpt-4o', 'https://api.openai.com/v1', 'openai_platform')
+    ''')
+    conn.commit()
+    conn.close()
+
+
+class TestBedrockMigration(unittest.TestCase):
+    """AWS Bedrock migration is idempotent and adds correct columns."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, 'settings.db')
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _get_columns(self):
+        """Return set of column names in llm_providers table."""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(llm_providers)")
+        cols = {col[1] for col in cursor.fetchall()}
+        conn.close()
+        return cols
+
+    def test_migration_adds_columns(self):
+        """Migration adds all four AWS columns to existing table."""
+        _create_minimal_db(self.db_path)
+        migrate_add_aws_bedrock_config(self.db_path)
+        cols = self._get_columns()
+        for col in ('aws_region', 'aws_profile', 'aws_access_key_id', 'aws_secret_access_key'):
+            self.assertIn(col, cols)
+
+    def test_migration_is_idempotent(self):
+        """Running migration twice does not error or duplicate columns."""
+        _create_minimal_db(self.db_path)
+        migrate_add_aws_bedrock_config(self.db_path)
+        migrate_add_aws_bedrock_config(self.db_path)
+        cols = self._get_columns()
+        aws_cols = [c for c in cols if c.startswith('aws_')]
+        self.assertEqual(len(aws_cols), 4)
+
+    def test_existing_data_preserved(self):
+        """Existing provider rows keep their data after migration."""
+        _create_minimal_db(self.db_path)
+        migrate_add_aws_bedrock_config(self.db_path)
+
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT name, model, provider_type FROM llm_providers ORDER BY name")
+        rows = cursor.fetchall()
+        conn.close()
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0][0], 'test-ollama')
+        self.assertEqual(rows[1][0], 'test-openai')
+
+    def test_new_columns_have_default_values(self):
+        """New AWS columns default to empty string."""
+        _create_minimal_db(self.db_path)
+        migrate_add_aws_bedrock_config(self.db_path)
+
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT aws_region, aws_profile, aws_access_key_id, aws_secret_access_key
+            FROM llm_providers WHERE name = 'test-ollama'
+        ''')
+        row = cursor.fetchone()
+        conn.close()
+
+        for val in row:
+            self.assertEqual(val, '')
+
+    def test_migration_on_empty_db(self):
+        """Migration works on a database with no rows."""
+        conn = sqlite3.connect(self.db_path)
+        conn.execute('''
+            CREATE TABLE llm_providers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL
+            )
+        ''')
+        conn.close()
+        migrate_add_aws_bedrock_config(self.db_path)
+        cols = self._get_columns()
+        for col in ('aws_region', 'aws_profile', 'aws_access_key_id', 'aws_secret_access_key'):
+            self.assertIn(col, cols)
+
+    def test_migration_on_already_migrated_db(self):
+        """Migration handles a table that already has AWS columns."""
+        conn = sqlite3.connect(self.db_path)
+        conn.execute('''
+            CREATE TABLE llm_providers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                aws_region TEXT DEFAULT '',
+                aws_profile TEXT DEFAULT '',
+                aws_access_key_id TEXT DEFAULT '',
+                aws_secret_access_key TEXT DEFAULT ''
+            )
+        ''')
+        conn.close()
+        migrate_add_aws_bedrock_config(self.db_path)
+        cols = self._get_columns()
+        for col in ('aws_region', 'aws_profile', 'aws_access_key_id', 'aws_secret_access_key'):
+            self.assertIn(col, cols)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -1,0 +1,284 @@
+"""Tests for BedrockProvider with mocked boto3."""
+
+import sys
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.services.models.llm_models import (
+    ChatRequest, ChatMessage, MessageRole, Usage
+)
+from src.services.models.provider_types import ProviderType
+
+
+BEDROCK_MODULE = 'src.services.llm_providers.bedrock_provider'
+BASE_CONFIG = {
+    'name': 'Test Bedrock',
+    'model': 'anthropic.claude-sonnet-4-6',
+    'provider_type': 'bedrock',
+    'aws_region': 'us-east-1',
+    'rate_limit_max_retries': 1,
+    'rate_limit_min_delay': 0.01,
+    'rate_limit_max_delay': 0.01,
+}
+
+
+class TestBedrockProviderChat(unittest.TestCase):
+    """BedrockProvider chat completion with mocked Converse API."""
+
+    def setUp(self):
+        """Create a BedrockProvider with a mocked boto3 client."""
+        self.config = dict(BASE_CONFIG)
+
+        self.mock_converse_response = {
+            'output': {
+                'message': {
+                    'role': 'assistant',
+                    'content': [{'text': 'Hello from Bedrock!'}]
+                }
+            },
+            'stopReason': 'end_turn',
+            'usage': {
+                'inputTokens': 10,
+                'outputTokens': 5,
+            },
+        }
+
+        self.mock_converse_stream_response = {
+            'stream': [
+                {'messageStart': {'role': 'assistant', 'messageId': 'msg-1'}},
+                {'contentBlockDelta': {
+                    'contentBlockIndex': 0,
+                    'delta': {'text': 'Hello '}
+                }},
+                {'contentBlockDelta': {
+                    'contentBlockIndex': 0,
+                    'delta': {'text': 'from Bedrock!'}
+                }},
+                {'messageStop': {'stopReason': 'end_turn'}},
+                {'metadata': {
+                    'usage': {'inputTokens': 10, 'outputTokens': 5}
+                }},
+            ]
+        }
+
+        self.mock_list_models_response = {
+            'modelSummaries': [
+                {'modelId': 'anthropic.claude-sonnet-4-6', 'modelName': 'Claude Sonnet 4.6'},
+                {'modelId': 'amazon.nova-pro-v1:0', 'modelName': 'Nova Pro'},
+            ]
+        }
+
+    def _create_provider(self):
+        """Import and create a BedrockProvider (lazy import after mock setup)."""
+        from src.services.llm_providers.bedrock_provider import BedrockProvider
+        return BedrockProvider(self.config)
+
+    def _make_request(self, text="Hello"):
+        """Create a simple ChatRequest."""
+        return ChatRequest(
+            messages=[ChatMessage(role=MessageRole.USER, content=text)],
+            model=self.config['model'],
+            max_tokens=100,
+        )
+
+    @patch(BEDROCK_MODULE + '.boto3')
+    async def _do_chat(self, mock_boto3):
+        """Helper to run a single chat completion."""
+        mock_client = MagicMock()
+        mock_client.converse.return_value = self.mock_converse_response
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
+
+        provider = self._create_provider()
+        request = self._make_request()
+        response = await provider.chat_completion(request)
+
+        return response, mock_client
+
+    def test_chat_completion_returns_content(self):
+        """chat_completion returns text from mock Converse API."""
+        import asyncio
+        response, client = asyncio.run(self._do_chat())
+        self.assertEqual(response.content, 'Hello from Bedrock!')
+        self.assertEqual(response.finish_reason, 'stop')
+
+    def test_chat_completion_returns_usage(self):
+        """chat_completion returns usage tokens."""
+        import asyncio
+        response, client = asyncio.run(self._do_chat())
+        self.assertEqual(response.usage.prompt_tokens, 10)
+        self.assertEqual(response.usage.completion_tokens, 5)
+        self.assertEqual(response.usage.total_tokens, 15)
+
+    def test_chat_completion_calls_converse(self):
+        """chat_completion calls client.converse() with correct args."""
+        import asyncio
+        response, client = asyncio.run(self._do_chat())
+        client.converse.assert_called_once()
+        call_kwargs = client.converse.call_args[1]
+        self.assertEqual(call_kwargs['modelId'], 'anthropic.claude-sonnet-4-6')
+        self.assertEqual(len(call_kwargs['messages']), 1)
+        self.assertEqual(call_kwargs['messages'][0]['role'], 'user')
+
+    @patch(BEDROCK_MODULE + '.boto3')
+    def test_chat_completion_with_system_prompt(self, mock_boto3):
+        """System message is sent in Converse 'system' field."""
+        import asyncio
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = self.mock_converse_response
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
+
+        provider = self._create_provider()
+        request = ChatRequest(
+            messages=[
+                ChatMessage(role=MessageRole.SYSTEM, content="You are a helpful assistant."),
+                ChatMessage(role=MessageRole.USER, content="Hello"),
+            ],
+            model=self.config['model'],
+        )
+        asyncio.run(provider.chat_completion(request))
+
+        call_kwargs = mock_client.converse.call_args[1]
+        self.assertIn('system', call_kwargs)
+        self.assertEqual(call_kwargs['system'][0]['text'], "You are a helpful assistant.")
+
+    @patch(BEDROCK_MODULE + '.boto3')
+    def test_chat_completion_stream_yields_chunks(self, mock_boto3):
+        """Stream returns content chunks and final metadata."""
+        import asyncio
+
+        mock_client = MagicMock()
+        mock_client.converse_stream.return_value = self.mock_converse_stream_response
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
+
+        provider = self._create_provider()
+        request = self._make_request()
+
+        async def consume():
+            chunks = []
+            async for chunk in provider.chat_completion_stream(request):
+                chunks.append(chunk)
+            return chunks
+
+        chunks = asyncio.run(consume())
+
+        self.assertGreaterEqual(len(chunks), 2)
+        texts = [c.content for c in chunks if c.is_streaming]
+        final_chunks = [c for c in chunks if not c.is_streaming]
+
+        combined = ''.join(texts)
+        self.assertIn('Hello', combined)
+        self.assertIn('Bedrock', combined)
+
+        self.assertEqual(len(final_chunks), 1)
+        self.assertEqual(final_chunks[0].usage.total_tokens, 15)
+
+    @patch(BEDROCK_MODULE + '.boto3')
+    def test_test_connection_success(self, mock_boto3):
+        """test_connection returns True when Bedrock API responds."""
+        import asyncio
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = self.mock_list_models_response
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
+
+        provider = self._create_provider()
+        result = asyncio.run(provider.test_connection())
+        self.assertTrue(result)
+
+    @patch(BEDROCK_MODULE + '.boto3')
+    def test_test_connection_failure(self, mock_boto3):
+        """test_connection returns False on ClientError."""
+        import asyncio
+        from botocore.exceptions import ClientError
+
+        error_response = {'Error': {'Code': 'AccessDeniedException', 'Message': 'Not authorized'}}
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.side_effect = ClientError(error_response, 'list_foundation_models')
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
+
+        provider = self._create_provider()
+        result = asyncio.run(provider.test_connection())
+        self.assertFalse(result)
+
+    @patch(BEDROCK_MODULE + '.boto3')
+    def test_authentication_error(self, mock_boto3):
+        """chat_completion raises AuthenticationError on access denied."""
+        import asyncio
+        from botocore.exceptions import ClientError
+        from src.services.llm_providers.base_provider import AuthenticationError
+
+        error_response = {'Error': {'Code': 'AccessDeniedException', 'Message': 'Not authorized'}}
+        mock_client = MagicMock()
+        mock_client.converse.side_effect = ClientError(error_response, 'converse')
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
+
+        provider = self._create_provider()
+        request = self._make_request()
+
+        with self.assertRaises(AuthenticationError):
+            asyncio.run(provider.chat_completion(request))
+
+    @patch(BEDROCK_MODULE + '.boto3')
+    def test_rate_limit_error(self, mock_boto3):
+        """chat_completion raises RateLimitError on throttling."""
+        import asyncio
+        from botocore.exceptions import ClientError
+        from src.services.llm_providers.base_provider import RateLimitError
+
+        error_response = {'Error': {'Code': 'ThrottlingException', 'Message': 'Rate exceeded'}}
+        mock_client = MagicMock()
+        mock_client.converse.side_effect = ClientError(error_response, 'converse')
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
+
+        provider = self._create_provider()
+        request = self._make_request()
+
+        with self.assertRaises(RateLimitError):
+            asyncio.run(provider.chat_completion(request))
+
+    def test_get_provider_type(self):
+        """get_provider_type returns ProviderType.BEDROCK."""
+        provider = self._create_provider()
+        self.assertEqual(provider.get_provider_type(), ProviderType.BEDROCK)
+
+    def test_get_capabilities(self):
+        """get_capabilities returns expected capabilities."""
+        provider = self._create_provider()
+        caps = provider.get_capabilities()
+        self.assertTrue(caps.supports_chat)
+        self.assertTrue(caps.supports_streaming)
+        self.assertTrue(caps.supports_tools)
+        self.assertFalse(caps.supports_embeddings)
+
+    def test_embeddings_not_supported(self):
+        """generate_embeddings raises NotImplementedError."""
+        provider = self._create_provider()
+        from src.services.models.llm_models import EmbeddingRequest
+        with self.assertRaises(NotImplementedError):
+            import asyncio
+            asyncio.run(provider.generate_embeddings(
+                EmbeddingRequest(texts=["hello"])
+            ))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_provider_types.py
+++ b/tests/test_provider_types.py
@@ -1,0 +1,76 @@
+"""Tests for ProviderType enum - verifies BEDROCK and existing providers."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.services.models.provider_types import ProviderType
+
+
+class TestProviderTypeEnum(unittest.TestCase):
+    """ProviderType enum integrity checks."""
+
+    def test_bedrock_enum_exists(self):
+        """BEDROCK enum value exists and has correct string value."""
+        self.assertIn(ProviderType.BEDROCK, ProviderType)
+        self.assertEqual(ProviderType.BEDROCK.value, "bedrock")
+
+    def test_all_provider_types_have_display_names(self):
+        """Every ProviderType has a display name."""
+        for pt in ProviderType:
+            names = ProviderType.get_display_names()
+            self.assertIn(pt, names)
+            self.assertTrue(len(names[pt]) > 0)
+
+    def test_all_provider_types_have_default_urls(self):
+        """Every ProviderType has a default URL (may be empty)."""
+        for pt in ProviderType:
+            urls = ProviderType.get_default_urls()
+            self.assertIn(pt, urls)
+            self.assertIsInstance(urls[pt], str)
+
+    def test_all_provider_types_have_default_models(self):
+        """Every ProviderType has a default models list."""
+        for pt in ProviderType:
+            models = ProviderType.get_default_models()
+            self.assertIn(pt, models)
+            self.assertIsInstance(models[pt], list)
+
+    def test_bedrock_defaults(self):
+        """BEDROCK defaults are sensible."""
+        self.assertEqual(ProviderType.BEDROCK.default_url, "")
+        self.assertIn("anthropic.claude-sonnet-4-6", ProviderType.BEDROCK.default_models)
+        self.assertEqual(ProviderType.BEDROCK.display_name, "AWS Bedrock")
+
+    def test_bedrock_capabilities(self):
+        """BEDROCK supports chat, streaming, tools, not embeddings, not API key."""
+        self.assertTrue(ProviderType.supports_tool_calls(ProviderType.BEDROCK))
+        self.assertTrue(ProviderType.supports_streaming(ProviderType.BEDROCK))
+        self.assertFalse(ProviderType.supports_embeddings(ProviderType.BEDROCK))
+        self.assertFalse(ProviderType.requires_api_key(ProviderType.BEDROCK))
+        self.assertFalse(ProviderType.uses_oauth(ProviderType.BEDROCK))
+
+    def test_existing_providers_unchanged(self):
+        """Existing providers still have expected capabilities."""
+        self.assertTrue(ProviderType.supports_streaming(ProviderType.OPENAI_PLATFORM))
+        self.assertTrue(ProviderType.supports_streaming(ProviderType.ANTHROPIC_PLATFORM))
+        self.assertTrue(ProviderType.requires_api_key(ProviderType.OPENAI_PLATFORM))
+        self.assertFalse(ProviderType.requires_api_key(ProviderType.OLLAMA))
+        self.assertTrue(ProviderType.supports_embeddings(ProviderType.OLLAMA))
+        self.assertTrue(ProviderType.uses_oauth(ProviderType.GEMINI_OAUTH))
+
+    def test_provider_type_string_conversion(self):
+        """ProviderType converts to/from string correctly."""
+        self.assertEqual(str(ProviderType.BEDROCK), "bedrock")
+        self.assertIs(ProviderType("bedrock"), ProviderType.BEDROCK)
+
+    def test_no_duplicate_values(self):
+        """No two enum members share the same value."""
+        values = [pt.value for pt in ProviderType]
+        self.assertEqual(len(values), len(set(values)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -1,0 +1,159 @@
+"""Tests for SettingsService AWS field persistence via integration with DB."""
+
+import sys
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.services.migrations.add_aws_bedrock_config import migrate_add_aws_bedrock_config
+
+
+def _create_base_table(conn):
+    """Create llm_providers table with original schema."""
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS llm_providers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            model TEXT NOT NULL,
+            url TEXT NOT NULL,
+            max_tokens INTEGER DEFAULT 4096,
+            api_key TEXT,
+            disable_tls BOOLEAN DEFAULT 0,
+            provider_type TEXT DEFAULT 'openai_platform',
+            is_active BOOLEAN DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+
+class TestSettingsServiceAWSFields(unittest.TestCase):
+    """AWS provider fields via direct SQL (matches SettingsService API)."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, 'settings.db')
+        conn = sqlite3.connect(self.db_path)
+        _create_base_table(conn)
+        conn.commit()
+        conn.close()
+        migrate_add_aws_bedrock_config(self.db_path)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _add_provider(self, name, model, url, provider_type, **extra):
+        """Simulate SettingsService.add_llm_provider via direct SQL."""
+        fields = {
+            'name': name, 'model': model, 'url': url,
+            'provider_type': provider_type,
+            'aws_region': extra.get('aws_region', ''),
+            'aws_profile': extra.get('aws_profile', ''),
+            'aws_access_key_id': extra.get('aws_access_key_id', ''),
+            'aws_secret_access_key': extra.get('aws_secret_access_key', ''),
+        }
+        cols = ', '.join(fields.keys())
+        placeholders = ', '.join(['?'] * len(fields))
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            f'INSERT INTO llm_providers ({cols}) VALUES ({placeholders})',
+            list(fields.values())
+        )
+        provider_id = cursor.lastrowid
+        conn.commit()
+        conn.close()
+        return provider_id
+
+    def _get_providers(self):
+        """Simulate SettingsService.get_llm_providers via direct SQL."""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute('''
+            SELECT id, name, model, url, max_tokens, api_key, disable_tls,
+                   provider_type, is_active, aws_region, aws_profile,
+                   aws_access_key_id, aws_secret_access_key
+            FROM llm_providers ORDER BY name
+        ''')
+        providers = []
+        for row in cursor.fetchall():
+            providers.append({
+                'id': row[0], 'name': row[1], 'model': row[2],
+                'url': row[3], 'max_tokens': row[4], 'api_key': row[5],
+                'disable_tls': bool(row[6]), 'provider_type': row[7],
+                'is_active': bool(row[8]), 'aws_region': row[9],
+                'aws_profile': row[10], 'aws_access_key_id': row[11],
+                'aws_secret_access_key': row[12],
+            })
+        conn.close()
+        return providers
+
+    def test_add_provider_with_aws_fields(self):
+        """INSERT with AWS fields succeeds."""
+        pid = self._add_provider(
+            'Test AWS', 'anthropic.claude-sonnet-4-6', '',
+            'bedrock', aws_region='us-west-2',
+            aws_profile='my-profile', aws_access_key_id='AKIA123',
+            aws_secret_access_key='secret456',
+        )
+        self.assertGreater(pid, 0)
+
+    def test_get_provider_returns_aws_fields(self):
+        """SELECT returns stored AWS fields."""
+        self._add_provider(
+            'Test AWS', 'anthropic.claude-sonnet-4-6', '',
+            'bedrock', aws_region='us-west-2',
+            aws_profile='my-profile', aws_access_key_id='AKIA123',
+        )
+        providers = self._get_providers()
+        self.assertEqual(len(providers), 1)
+        p = providers[0]
+        self.assertEqual(p['aws_region'], 'us-west-2')
+        self.assertEqual(p['aws_profile'], 'my-profile')
+        self.assertEqual(p['aws_access_key_id'], 'AKIA123')
+
+    def test_non_bedrock_has_empty_aws_fields(self):
+        """Non-Bedrock providers have empty AWS fields."""
+        self._add_provider('Ollama', 'llama3.1:8b', 'http://localhost:11434', 'ollama')
+        providers = self._get_providers()
+        p = providers[0]
+        self.assertEqual(p['aws_region'], '')
+        self.assertEqual(p['aws_profile'], '')
+
+    def test_mixed_providers(self):
+        """Bedrock and non-Bedrock coexist."""
+        self._add_provider('Bedrock', 'anthropic.claude-sonnet-4-6', '', 'bedrock',
+                          aws_region='us-east-1')
+        self._add_provider('Ollama', 'llama3.1:8b', 'http://localhost:11434', 'ollama')
+        providers = self._get_providers()
+        self.assertEqual(len(providers), 2)
+        bedrock = [p for p in providers if p['name'] == 'Bedrock'][0]
+        ollama = [p for p in providers if p['name'] == 'Ollama'][0]
+        self.assertEqual(bedrock['aws_region'], 'us-east-1')
+        self.assertEqual(ollama['aws_region'], '')
+
+    def test_update_aws_fields(self):
+        """UPDATE modifies AWS fields correctly."""
+        pid = self._add_provider('Bedrock', 'anthropic.claude-sonnet-4-6', '', 'bedrock',
+                                aws_region='us-east-1')
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            'UPDATE llm_providers SET aws_region = ?, aws_profile = ? WHERE id = ?',
+            ('eu-west-1', 'prod', pid)
+        )
+        conn.commit()
+        conn.close()
+
+        providers = self._get_providers()
+        p = providers[0]
+        self.assertEqual(p['aws_region'], 'eu-west-1')
+        self.assertEqual(p['aws_profile'], 'prod')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements a first-class Bedrock provider using boto3 bedrock-runtime Converse/ConverseStream API, independent of the LiteLLM proxy path.

- New ProviderType.BEDROCK enum with proper capabilities
- BedrockProvider class with chat, streaming, tool use, error handling
- BedrockProviderFactory registered with graceful fallback
- Migration adds aws_region, aws_profile, aws_access_key_id, aws_secret_access_key columns to llm_providers table
- Settings UI with AWS credential fields (hidden unless bedrock type)
- boto3 dependency
- 40 unit tests (enum, factory, migration, provider, settings)
- Documentation updated with setup guide and pricing/quotas notice

# Note
I am not user of the IDE, but wanted to collaborate. I focused on not breaking the existing features.

Closes #13