### PR TITLE
Add proper compatibility with Open WebUI

### DIFF
--- a/src/services/llm_providers/openwebui_platform_api_provider.py
+++ b/src/services/llm_providers/openwebui_platform_api_provider.py
@@ -30,7 +30,7 @@ from ..models.reasoning_models import ReasoningConfig
 from src.ida_compat import log
 
 
-class OpenAIPlatformApiProvider(BaseLLMProvider):
+class OpenWebUIPlatformApiProvider(BaseLLMProvider):
     """
     OpenAI API provider implementation.
 
@@ -54,11 +54,6 @@ class OpenAIPlatformApiProvider(BaseLLMProvider):
         try:
             timeout = self.timeout
 
-            # Handle base_url - use default if not specified or standard OpenAI URL
-            base_url = None
-            if self.url and self.url != 'https://api.openai.com/v1':
-                base_url = self.url
-
             # For local providers that don't need API keys, use a placeholder
             api_key = self.api_key or "not-needed"
 
@@ -78,7 +73,7 @@ class OpenAIPlatformApiProvider(BaseLLMProvider):
 
                 self._client = OpenAI(
                     api_key=api_key,
-                    base_url=base_url,
+                    base_url=self.url,
                     timeout=timeout,
                     max_retries=0,  # We handle retries ourselves
                     http_client=http_client
@@ -92,7 +87,7 @@ class OpenAIPlatformApiProvider(BaseLLMProvider):
                     log.log_debug("OpenAI: Bypassing system proxy (trust_env=False)")
                 self._client = OpenAI(
                     api_key=api_key,
-                    base_url=base_url,
+                    base_url=self.url,
                     timeout=timeout,
                     max_retries=0,  # We handle retries ourselves
                     http_client=_http_client
@@ -103,12 +98,9 @@ class OpenAIPlatformApiProvider(BaseLLMProvider):
 
     def _is_reasoning_model(self) -> bool:
         """Check if the current model is an o* reasoning model."""
+        #TODOcheck if the info can be provided
         model_name = self.model.lower()
-        return (model_name.startswith("o1") or
-                model_name.startswith("o2") or
-                model_name.startswith("o3") or
-                model_name.startswith("o4") or
-                model_name.startswith("gpt-5"))
+        return True
 
     def _prepare_messages(self, messages: List[ChatMessage]) -> List[Dict[str, Any]]:
         """Convert BinAssist ChatMessage objects to OpenAI message format."""
@@ -644,23 +636,10 @@ class OpenAIPlatformApiProvider(BaseLLMProvider):
 
     def _get_models_endpoint_candidates(self) -> List[str]:
         """Resolve plausible OpenAI-compatible models endpoints from the configured base URL."""
-        base_url = (self.url or "https://api.openai.com/v1").strip().rstrip("/")
+        base_url = self.url + "/api"
         candidates: List[str] = []
 
-        def add(candidate: str):
-            if candidate and candidate not in candidates:
-                candidates.append(candidate)
-
-        if base_url.endswith("/models"):
-            add(base_url)
-            return candidates
-
-        add(f"{base_url}/models")
-
-        # Some OpenAI-compatible proxies are configured at the service root and
-        # expose models at `/v1/models` even when chat works at a different base.
-        if not base_url.endswith("/v1"):
-            add(f"{base_url}/v1/models")
+        candidates.append(base_url + "/models")
 
         return candidates
 
@@ -747,19 +726,16 @@ class OpenAIPlatformApiProvider(BaseLLMProvider):
 from ..llm_providers.provider_factory import ProviderFactory
 from ..models.provider_types import ProviderType
 
-class OpenAIPlatformApiProviderFactory(ProviderFactory):
+class OpenWebUIPlatformApiProviderFactory(ProviderFactory):
     """Factory for creating OpenAI Platform API provider instances"""
 
-    def create_provider(self, config: Dict[str, Any]) -> OpenAIPlatformApiProvider:
+    def create_provider(self, config: Dict[str, Any]) -> OpenWebUIPlatformApiProvider:
         """Create OpenAI Platform API provider instance"""
-        return OpenAIPlatformApiProvider(config)
+        return OpenWebUIPlatformApiProvider(config)
 
     def supports_provider_type(self, provider_type: ProviderType) -> bool:
         """Check if this factory supports the provider type"""
-        # OpenAI provider handles OpenAI-compatible APIs
+        # OpenAI like providers for special Open WebUI compat
         return provider_type in {
-            ProviderType.OPENAI_PLATFORM,
-            ProviderType.LMSTUDIO,
-            ProviderType.XAI_PLATFORM,
-            ProviderType.GEMINI_PLATFORM,
+            ProviderType.OPENWEBUI,
         }

--- a/src/services/llm_providers/openwebui_platform_api_provider.py
+++ b/src/services/llm_providers/openwebui_platform_api_provider.py
@@ -53,45 +53,35 @@ class OpenWebUIPlatformApiProvider(BaseLLMProvider):
         # Initialize OpenAI client
         try:
             timeout = self.timeout
-
+            import httpx
             # For local providers that don't need API keys, use a placeholder
             api_key = self.api_key or "not-needed"
-
+            verify = True
             # Handle TLS verification settings and create client
             if self.disable_tls:
-                import httpx
                 import ssl
                 log.log_warn(f"TLS verification disabled for OpenAI provider '{self.name}'")
-
                 # Create SSL context that doesn't verify certificates
                 ssl_context = ssl.create_default_context()
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE
-
+                verify = False
                 # Create httpx client with disabled verification
-                http_client = httpx.Client(verify=False, timeout=timeout)
-
-                self._client = OpenAI(
-                    api_key=api_key,
-                    base_url=self.url,
-                    timeout=timeout,
-                    max_retries=0,  # We handle retries ourselves
-                    http_client=http_client
-                )
             else:
-                import httpx
                 # Respect bypass_proxy setting (default False: use system proxy)
                 _bypass_proxy = self.config.get('bypass_proxy', False)
-                _http_client = httpx.Client(trust_env=not _bypass_proxy, timeout=timeout)
+                verify = not _bypass_proxy
                 if _bypass_proxy:
                     log.log_debug("OpenAI: Bypassing system proxy (trust_env=False)")
-                self._client = OpenAI(
-                    api_key=api_key,
-                    base_url=self.url,
-                    timeout=timeout,
-                    max_retries=0,  # We handle retries ourselves
-                    http_client=_http_client
-                )
+
+            http_client = httpx.Client(verify=verify, timeout=timeout)
+            self._client = OpenAI(
+                api_key=api_key,
+                base_url=self.url +"/api",
+                timeout=timeout,
+                max_retries=0,  # We handle retries ourselves
+                http_client=http_client
+            )
 
         except Exception as e:
             raise APIProviderError(f"Failed to initialize OpenAI client: {e}")
@@ -737,5 +727,5 @@ class OpenWebUIPlatformApiProviderFactory(ProviderFactory):
         """Check if this factory supports the provider type"""
         # OpenAI like providers for special Open WebUI compat
         return provider_type in {
-            ProviderType.OPENWEBUI,
+            ProviderType.OPENWEBUI
         }

--- a/src/services/llm_providers/provider_factory.py
+++ b/src/services/llm_providers/provider_factory.py
@@ -162,11 +162,17 @@ class LLMProviderFactory:
             openai_factory = OpenAIPlatformApiProviderFactory()
             self.register_factory(ProviderType.OPENAI_PLATFORM, openai_factory)
             self.register_factory(ProviderType.LMSTUDIO, openai_factory)
-            self.register_factory(ProviderType.OPENWEBUI, openai_factory)
             self.register_factory(ProviderType.XAI_PLATFORM, openai_factory)
             self.register_factory(ProviderType.GEMINI_PLATFORM, openai_factory)
         except ImportError:
             pass  # OpenAI Platform API provider not available
+
+        try:
+            from .openwebui_platform_api_provider import OpenWebUIPlatformApiProviderFactory
+            openwebui_factory = OpenWebUIPlatformApiProviderFactory()
+            self.register_factory(ProviderType.OPENWEBUI, openwebui_factory)
+        except ImportError:
+            pass  # WEbUI Platform API provider not available
 
         # Gemini OAuth provider (Gemini CLI subscription)
         try:


### PR DESCRIPTION
Open WebUI provide API to /api/ instead of /v1/  like the OpenAI and general API expect.

Provide a new specific factory that call manually /api/models and instruct the rest of the OpenAI API to use /api/ inside the basepath 
Close #15 